### PR TITLE
Add correct parameters to determinant3 function

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ const d = determinant2(1, 1, 2, 2);
 Returns the determinant of a passed 3x3 matrix:
 
 ```js
-const d = determinant3(1, 1, 1, 2, 2, 2);
+const d = determinant3(1, 1, 1, 2, 2, 2, 3, 3, 3);
 ```
 
 #### 🪶 determinant4(...matrixInRowMajorOrder) // TBD


### PR DESCRIPTION
determinant3 takes 9 parameters since it is 3x3 matrix, but the example in the ReadMe only passed 6. This PR adds the missing 3.