### PR TITLE
feat(three): add Math bridge for Three

### DIFF
--- a/API.md
+++ b/API.md
@@ -13,6 +13,7 @@ overview, installation, and examples, see the [README](./README.md).
 - [`math/noise`](#api-math-noise) — Perlin, simplex & worley noise, plus fractal helpers
 - [`math/color`](#api-math-color) — Color & colorspace utilities
 - [`math/ik`](#api-math-ik) — Inverse kinematics
+- [`math/three`](#api-math-three) — Zero-copy bridge to three.js: extend a scene so math drives its transforms
 
 ---
 
@@ -1603,3 +1604,37 @@ import { fabrik3 } from 'math/ik';
 - `fabrik3.getBoneDirection(out: Vec3, chain: Chain3, index: number): Vec3` — Writes the unit direction of bone `index`, from its start toward its end, into `out`.
 - `fabrik3.getBoneRotation(out: Quat, chain: Chain3, index: number, up: Vec3): Quat` — Writes the rotation taking `up` onto the direction of bone `index` into `out`.
 - `fabrik3.isReachable(chain: Chain3, target: Vec3): boolean` — Whether `target` is within reach of the chain's base, so a solve can place the effector exactly on it.
+
+<a id="api-math-three"></a>
+
+## `math/three`
+
+**Types**
+
+- `type Transform = { position: Vec3; rotation: Quat; scale: Vec3; local: Mat4; world: Mat4; }` — The math side of an extended object. Stable for as long as the object stays extended.
+
+**Create**
+
+- <a id="frustumfromcamera"></a>`frustumFromCamera(out: Frustum, camera: Camera): Frustum` — Extracts a frustum for a camera using WebGL depth in [-1, 1].
+
+**Operations**
+
+- <a id="extend"></a>`extend<T extends Object3D>(scene: T): T` — Extends every object under `scene` and makes the scene's own update entry points run the
+- <a id="extendobject"></a>`extendObject(object: Object3D): Transform` — Extends one object on its own, such as a camera outside the scene tree. Its own
+- <a id="propagate"></a>`propagate(scene: Object3D): void` — One flat pass over the scene: compose extended nodes from their records, propagate world matrices.
+- <a id="release"></a>`release(object: Object3D): void` — Gives an object its plain three transform back. An object that stays in an extended scene
+- <a id="unextend"></a>`unextend(scene: Object3D): void` — Undoes extend: every object under the scene gets plain transforms back, the scene its own methods.
+- <a id="claimtransform"></a>`claimTransform(object: Object3D): { local: Mat4; world: Mat4; }` — Disables automatic transform updates. The caller owns the local and world matrices
+- <a id="instancemat4views"></a>`instanceMat4Views(mesh: InstancedMesh): Mat4[]` — Allocates one Mat4 view per instance over the upload buffer. Call once at setup and set
+- <a id="mat4of"></a>`mat4Of(m: Matrix4): Mat4` — A three Matrix4's storage, usable as a math Mat4 with no cast and no copy
+- <a id="quatfromquaternion"></a>`quatFromQuaternion(out: Quat, q: Quaternion): Quat`
+- <a id="quattoquaternion"></a>`quatToQuaternion(out: Quaternion, q: Quat): Quaternion` — Fires the quaternion's change callback once. On an Object3D's quaternion that re-derives `rotation`.
+- <a id="spheretoworld"></a>`sphereToWorld(out: Sphere, local: ThreeSphere, world: Mat4): Sphere` — Transforms a local bounding sphere to world space. Scales the radius by the largest
+- <a id="vec3fromattribute"></a>`vec3FromAttribute(out: Vec3, attribute: BufferAttribute, index: number): Vec3` — Reads vertex `index` of a 3-component attribute into a Vec3, denormalizing like `getX` does.
+- <a id="vec3fromvector3"></a>`vec3FromVector3(out: Vec3, v: Vector3): Vec3`
+- <a id="vec3toattribute"></a>`vec3ToAttribute(attribute: BufferAttribute, a: Vec3, index: number): void` — Writes a Vec3 into vertex `index` of a 3-component attribute, normalizing like `setXYZ` does. Set `needsUpdate` afterwards.
+- <a id="vec3tovector3"></a>`vec3ToVector3(out: Vector3, a: Vec3): Vector3`
+
+**Transform**
+
+- <a id="transformof"></a>`transformOf(object: Object3D): Transform` — The Transform of an extended object. Throws for an object that is not extended.

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ math is a collection of math helpers for graphics and simulations.
 | [`math/noise`](API.md#api-math-noise) | Perlin, simplex & worley noise, plus fractal helpers | [`perlin2d`](API.md#api-math-noise-perlin2d) [`perlin3d`](API.md#api-math-noise-perlin3d) [`simplex2d`](API.md#api-math-noise-simplex2d) [`simplex3d`](API.md#api-math-noise-simplex3d) [`simplex4d`](API.md#api-math-noise-simplex4d) [`worley2d`](API.md#api-math-noise-worley2d) [`worley3d`](API.md#api-math-noise-worley3d) [`fbm`](API.md#fbm) [`ridged`](API.md#ridged) [`billow`](API.md#billow) [`domainWarp2`](API.md#domainwarp2) [`domainWarp3`](API.md#domainwarp3) [`curl2`](API.md#curl2) [`curl3`](API.md#curl3) |
 | [`math/color`](API.md#api-math-color) | Color & colorspace utilities | [`color`](API.md#api-math-color-color) [`colorspace`](API.md#api-math-color-colorspace) [`hsl`](API.md#api-math-color-hsl) |
 | [`math/ik`](API.md#api-math-ik) | Inverse kinematics | [`fabrik2`](API.md#api-math-ik-fabrik2) [`fabrik3`](API.md#api-math-ik-fabrik3) |
+| [`math/three`](API.md#api-math-three) | Zero-copy bridge to three.js: extend a scene so math drives its transforms | [`extend`](API.md#extend) [`extendObject`](API.md#extendobject) [`propagate`](API.md#propagate) [`release`](API.md#release) [`transformOf`](API.md#transformof) [`unextend`](API.md#unextend) [`claimTransform`](API.md#claimtransform) [`frustumFromCamera`](API.md#frustumfromcamera) [`instanceMat4Views`](API.md#instancemat4views) [`mat4Of`](API.md#mat4of) [`quatFromQuaternion`](API.md#quatfromquaternion) [`quatToQuaternion`](API.md#quattoquaternion) [`sphereToWorld`](API.md#spheretoworld) [`vec3FromAttribute`](API.md#vec3fromattribute) [`vec3FromVector3`](API.md#vec3fromvector3) [`vec3ToAttribute`](API.md#vec3toattribute) [`vec3ToVector3`](API.md#vec3tovector3) |
 
 
 ## Quick Start
@@ -48,7 +49,7 @@ import { simplex3d } from 'math/noise'; // perlin / simplex noise
 import { mulberry32 } from 'math/random'; // seeded rng
 import { easing, spring } from 'math/time'; // easings & springs
 import { fabrik2, fabrik3 } from 'math/ik'; // inverse kinematics
-// also: math/color, math/geometry, math/shapes — import only what you use
+// Other modules: math/color, math/geometry, math/shapes and math/three.
 ```
 
 ## Examples

--- a/benches/README.md
+++ b/benches/README.md
@@ -24,6 +24,9 @@ pnpm bench --no-save      # run without saving
   navigation/collision-style libraries, exercising many math functions together: funnel string
   pulling (`@nav`), frustum culling (`@culling`), closest-hit raycasting (`@raycast`), transform
   hierarchy propagation (`@scene`), and a full sphere physics step (`@physics`)
+- `three/` — the math + three.js bridge experiment (`@three`): the same frame of work written
+  with three's own API and with math writing into three's storage in place, outputs asserted
+  equal. See [three/README.md](./three/README.md)
 
 The composite benches run 100+ µs per iteration, which keeps them well above this machine's
 micro-bench noise floor — prefer them for regression comparisons; use the micro benches to

--- a/benches/package.json
+++ b/benches/package.json
@@ -4,11 +4,13 @@
   "version": "0.0.0",
   "type": "module",
   "dependencies": {
-    "@pmndrs/labs": "^0.9.0"
+    "@pmndrs/labs": "^0.9.0",
+    "three": "0.185.1"
   },
   "devDependencies": {
+    "@types/three": "0.185.4",
     "tsx": "^4.21.0",
-    "typescript": "^5.9.2"
+    "typescript": "^5.9.2",
+    "vite": "^7.3.6"
   }
 }
-  

--- a/benches/three/culling.bench.ts
+++ b/benches/three/culling.bench.ts
@@ -1,0 +1,23 @@
+import { assert, bench, group } from '@pmndrs/labs';
+import { MESHES, createCulling, createMathCulling, cullMath, cullThree } from './culling';
+
+// Plane extraction can round differently for spheres touching the frustum boundary.
+
+group(`three frustum culling ${MESHES} @three @culling`, () => {
+    bench('three: Frustum.intersectsObject', function* () {
+        const s = createCulling(MESHES);
+        const expected = cullMath(s, createMathCulling(s));
+        const visible = yield () => cullThree(s);
+        assert(visible === expected, `three saw ${visible} visible, math saw ${expected}`);
+        return visible;
+    });
+
+    bench('math: frustumFromCamera + sphereToWorld', function* () {
+        const s = createCulling(MESHES);
+        const c = createMathCulling(s);
+        const expected = cullThree(s);
+        const visible = yield () => cullMath(s, c);
+        assert(visible === expected, `math saw ${visible} visible, three saw ${expected}`);
+        return visible;
+    });
+});

--- a/benches/three/culling.ts
+++ b/benches/three/culling.ts
@@ -1,0 +1,84 @@
+import type { Sphere as ThreeSphere } from 'three';
+import { Frustum, Matrix4, Mesh, MeshBasicMaterial, PerspectiveCamera, Scene, SphereGeometry, Vector3 } from 'three';
+import type { Mat4 } from '../../src/core/mat4';
+import * as mulberry32 from '../../src/random/mulberry32';
+import * as frustum from '../../src/shapes/frustum';
+import * as sphere from '../../src/shapes/sphere';
+import { frustumFromCamera, sphereToWorld } from '../../src/three';
+
+// Cull bounding spheres against a perspective camera. Both variants read three's matrices.
+
+export const MESHES = 4096;
+
+const AXIS = new Vector3(0.267261, 0.534522, 0.801784);
+
+export function createCulling(count: number) {
+    const rand = mulberry32.create(42);
+    const scene = new Scene();
+    const geometry = new SphereGeometry(1, 8, 6);
+    geometry.computeBoundingSphere();
+    const material = new MeshBasicMaterial();
+    const meshes: Mesh[] = [];
+    for (let i = 0; i < count; i++) {
+        const mesh = new Mesh(geometry, material);
+        mesh.position.set(
+            (mulberry32.sample(rand) - 0.5) * 80,
+            (mulberry32.sample(rand) - 0.5) * 80,
+            (mulberry32.sample(rand) - 0.5) * 80,
+        );
+        mesh.scale.set(
+            0.5 + mulberry32.sample(rand) * 1.5,
+            0.5 + mulberry32.sample(rand) * 1.5,
+            0.5 + mulberry32.sample(rand) * 1.5,
+        );
+        mesh.quaternion.setFromAxisAngle(AXIS, mulberry32.sample(rand) * Math.PI * 2);
+        scene.add(mesh);
+        meshes.push(mesh);
+    }
+    const camera = new PerspectiveCamera(60, 16 / 9, 0.1, 100);
+    camera.position.set(30, 30, 30);
+    camera.lookAt(0, 0, 0);
+    camera.updateMatrixWorld();
+    scene.updateMatrixWorld();
+    return { scene, camera, meshes, count };
+}
+export type Culling = ReturnType<typeof createCulling>;
+
+const projScreen = new Matrix4();
+const threeFrustum = new Frustum();
+
+export function cullThree(s: Culling): number {
+    const { camera, meshes, count } = s;
+    projScreen.multiplyMatrices(camera.projectionMatrix, camera.matrixWorldInverse);
+    threeFrustum.setFromProjectionMatrix(projScreen);
+    let visible = 0;
+    for (let i = 0; i < count; i++) {
+        if (threeFrustum.intersectsObject(meshes[i])) visible++;
+    }
+    return visible;
+}
+
+export function createMathCulling(s: Culling) {
+    const worlds: Mat4[] = new Array(s.count);
+    const spheres: ThreeSphere[] = new Array(s.count);
+    for (let i = 0; i < s.count; i++) {
+        const mesh = s.meshes[i];
+        worlds[i] = mesh.matrixWorld.elements;
+        const bounds = mesh.geometry.boundingSphere;
+        if (bounds === null) throw new Error('geometry has no bounding sphere');
+        spheres[i] = bounds;
+    }
+    return { worlds, spheres, f: frustum.create(), s: sphere.create() };
+}
+export type MathCulling = ReturnType<typeof createMathCulling>;
+
+export function cullMath(s: Culling, c: MathCulling): number {
+    const { worlds, spheres, f } = c;
+    frustumFromCamera(f, s.camera);
+    let visible = 0;
+    for (let i = 0; i < s.count; i++) {
+        sphereToWorld(c.s, spheres[i], worlds[i]);
+        if (frustum.intersectsSphere(f, c.s)) visible++;
+    }
+    return visible;
+}

--- a/benches/three/geometry.bench.ts
+++ b/benches/three/geometry.bench.ts
@@ -1,0 +1,35 @@
+import { assert, bench, group } from '@pmndrs/labs';
+import { checksum, createGeometry, createMathGeometry, maxDifference, transformMath, transformThree } from './geometry';
+
+// Normal matrix arithmetic can differ by one float32 rounding step.
+
+function threeReference() {
+    const g = createGeometry();
+    transformThree(g);
+    return g;
+}
+
+function mathReference() {
+    const g = createGeometry();
+    transformMath(g, createMathGeometry());
+    return g;
+}
+
+group('three geometry transform 8481 vertices @three @geometry', () => {
+    bench('three: fromBufferAttribute/applyMatrix4/setXYZ', function* () {
+        const g = createGeometry();
+        yield () => transformThree(g);
+        const diff = maxDifference(g, mathReference());
+        assert(diff <= 1e-5, `three and math attributes differ by ${diff}`);
+        return checksum(g);
+    });
+
+    bench('math: fromBuffer/transformMat4/toBuffer', function* () {
+        const g = createGeometry();
+        const w = createMathGeometry();
+        yield () => transformMath(g, w);
+        const diff = maxDifference(g, threeReference());
+        assert(diff <= 1e-5, `math and three attributes differ by ${diff}`);
+        return checksum(g);
+    });
+});

--- a/benches/three/geometry.ts
+++ b/benches/three/geometry.ts
@@ -1,0 +1,83 @@
+import { BufferAttribute, Matrix3, Matrix4, Quaternion, TorusKnotGeometry, Vector3 } from 'three';
+import * as mat3 from '../../src/core/mat3';
+import * as vec3 from '../../src/core/vec3';
+import { mat4Of, vec3FromAttribute, vec3ToAttribute } from '../../src/three';
+
+// Transform source positions and normals into destination attributes for CPU deformation.
+
+export function createGeometry() {
+    const source = new TorusKnotGeometry(1, 0.3, 256, 32);
+    const sourcePosition = source.getAttribute('position') as BufferAttribute;
+    const sourceNormal = source.getAttribute('normal') as BufferAttribute;
+    const vertexCount = sourcePosition.count;
+    const position = new BufferAttribute(new Float32Array(vertexCount * 3), 3);
+    const normal = new BufferAttribute(new Float32Array(vertexCount * 3), 3);
+    const matrix = new Matrix4().compose(
+        new Vector3(1, 2, 3),
+        new Quaternion().setFromAxisAngle(new Vector3(0.267261, 0.534522, 0.801784), 0.7),
+        new Vector3(1, 2, 0.5),
+    );
+    return { sourcePosition, sourceNormal, position, normal, matrix, vertexCount };
+}
+export type Geometry = ReturnType<typeof createGeometry>;
+
+const v = new Vector3();
+const n = new Vector3();
+const normalMatrix = new Matrix3();
+
+export function transformThree(g: Geometry): void {
+    const { sourcePosition, sourceNormal, position, normal, matrix, vertexCount } = g;
+    normalMatrix.getNormalMatrix(matrix);
+    for (let i = 0; i < vertexCount; i++) {
+        v.fromBufferAttribute(sourcePosition, i).applyMatrix4(matrix);
+        position.setXYZ(i, v.x, v.y, v.z);
+        n.fromBufferAttribute(sourceNormal, i).applyNormalMatrix(normalMatrix);
+        normal.setXYZ(i, n.x, n.y, n.z);
+    }
+    position.needsUpdate = true;
+    normal.needsUpdate = true;
+}
+
+export function createMathGeometry() {
+    return { v: vec3.create(), n: vec3.create(), nm: mat3.create() };
+}
+export type MathGeometry = ReturnType<typeof createMathGeometry>;
+
+export function transformMath(g: Geometry, w: MathGeometry): void {
+    const { sourcePosition, sourceNormal, position, normal, vertexCount } = g;
+    const { v, n, nm } = w;
+    const m = mat4Of(g.matrix);
+    if (mat3.normalFromMat4(nm, m) === null) throw new Error('singular matrix');
+    for (let i = 0; i < vertexCount; i++) {
+        vec3FromAttribute(v, sourcePosition, i);
+        vec3.transformMat4(v, v, m);
+        vec3ToAttribute(position, v, i);
+        vec3FromAttribute(n, sourceNormal, i);
+        vec3.transformMat3(n, n, nm);
+        vec3.normalize(n, n);
+        vec3ToAttribute(normal, n, i);
+    }
+    position.needsUpdate = true;
+    normal.needsUpdate = true;
+}
+
+export function checksum(g: Geometry): number {
+    const p = g.position.array;
+    const nn = g.normal.array;
+    let sum = 0;
+    for (let i = 0; i < p.length; i++) sum += p[i] + nn[i];
+    return sum;
+}
+
+/** Largest absolute element difference between two geometries' destination attributes. */
+export function maxDifference(a: Geometry, b: Geometry): number {
+    const pa = a.position.array;
+    const pb = b.position.array;
+    const na = a.normal.array;
+    const nb = b.normal.array;
+    let max = 0;
+    for (let i = 0; i < pa.length; i++) {
+        max = Math.max(max, Math.abs(pa[i] - pb[i]), Math.abs(na[i] - nb[i]));
+    }
+    return max;
+}

--- a/benches/three/instanced.bench.ts
+++ b/benches/three/instanced.bench.ts
@@ -1,0 +1,52 @@
+import { assert, bench, group } from '@pmndrs/labs';
+import {
+    FRAME_T,
+    INSTANCES,
+    checksum,
+    createInstanced,
+    createMathInstanced,
+    updateMath,
+    updateThreeCompose,
+    updateThreeObject3D,
+} from './instanced';
+
+// Snapshot instance buffer checksums after the measured work.
+
+function mathReference(): number {
+    const s = createInstanced(INSTANCES);
+    updateMath(s, createMathInstanced(s), FRAME_T);
+    return checksum(s);
+}
+
+function threeReference(): number {
+    const s = createInstanced(INSTANCES);
+    updateThreeObject3D(s, FRAME_T);
+    return checksum(s);
+}
+
+group(`three instanced transforms ${INSTANCES} @three @instanced`, () => {
+    bench('three: Object3D dummy + setMatrixAt', function* () {
+        const s = createInstanced(INSTANCES);
+        yield () => updateThreeObject3D(s, FRAME_T);
+        const sum = checksum(s);
+        assert(sum === mathReference(), 'three and math instance buffers differ');
+        return sum;
+    });
+
+    bench('three: Matrix4.compose + setMatrixAt', function* () {
+        const s = createInstanced(INSTANCES);
+        yield () => updateThreeCompose(s, FRAME_T);
+        const sum = checksum(s);
+        assert(sum === mathReference(), 'three (compose) and math instance buffers differ');
+        return sum;
+    });
+
+    bench('math: compose into instance buffer views', function* () {
+        const s = createInstanced(INSTANCES);
+        const m = createMathInstanced(s);
+        yield () => updateMath(s, m, FRAME_T);
+        const sum = checksum(s);
+        assert(sum === threeReference(), 'math and three instance buffers differ');
+        return sum;
+    });
+});

--- a/benches/three/instanced.ts
+++ b/benches/three/instanced.ts
@@ -1,0 +1,88 @@
+import { BoxGeometry, InstancedMesh, Matrix4, MeshBasicMaterial, Object3D, Quaternion, Vector3 } from 'three';
+import * as mat4 from '../../src/core/mat4';
+import * as quat from '../../src/core/quat';
+import type { Vec3 } from '../../src/core/vec3';
+import * as vec3 from '../../src/core/vec3';
+import * as mulberry32 from '../../src/random/mulberry32';
+import { instanceMat4Views } from '../../src/three';
+
+// Each variant moves instances on a sine wave and rotates them about a fixed axis.
+
+export const INSTANCES = 10000;
+export const FRAME_T = 0.5;
+
+const AXIS: Vec3 = [0.267261, 0.534522, 0.801784];
+const ONE: Vec3 = [1, 1, 1];
+
+export function createInstanced(count: number) {
+    const rand = mulberry32.create(7);
+    const mesh = new InstancedMesh(new BoxGeometry(), new MeshBasicMaterial(), count);
+    const base = new Float64Array(count * 3);
+    const phase = new Float64Array(count);
+    for (let i = 0; i < count; i++) {
+        base[i * 3] = (mulberry32.sample(rand) - 0.5) * 100;
+        base[i * 3 + 1] = (mulberry32.sample(rand) - 0.5) * 100;
+        base[i * 3 + 2] = (mulberry32.sample(rand) - 0.5) * 100;
+        phase[i] = mulberry32.sample(rand) * Math.PI * 2;
+    }
+    return { mesh, count, base, phase };
+}
+export type Instanced = ReturnType<typeof createInstanced>;
+
+// Reuse one Object3D to compose every instance matrix.
+const dummy = new Object3D();
+const threeAxis = new Vector3(AXIS[0], AXIS[1], AXIS[2]);
+
+export function updateThreeObject3D(s: Instanced, t: number): void {
+    const { mesh, count, base, phase } = s;
+    for (let i = 0; i < count; i++) {
+        const o = i * 3;
+        dummy.position.set(base[o], base[o + 1] + Math.sin(t + phase[i]), base[o + 2]);
+        dummy.quaternion.setFromAxisAngle(threeAxis, phase[i] + t);
+        dummy.updateMatrix();
+        mesh.setMatrixAt(i, dummy.matrix);
+    }
+    mesh.instanceMatrix.needsUpdate = true;
+}
+
+// Bare transform objects avoid Object3D's Euler synchronization.
+const position = new Vector3();
+const rotation = new Quaternion();
+const scale = new Vector3(1, 1, 1);
+const matrix = new Matrix4();
+
+export function updateThreeCompose(s: Instanced, t: number): void {
+    const { mesh, count, base, phase } = s;
+    for (let i = 0; i < count; i++) {
+        const o = i * 3;
+        position.set(base[o], base[o + 1] + Math.sin(t + phase[i]), base[o + 2]);
+        rotation.setFromAxisAngle(threeAxis, phase[i] + t);
+        matrix.compose(position, rotation, scale);
+        mesh.setMatrixAt(i, matrix);
+    }
+    mesh.instanceMatrix.needsUpdate = true;
+}
+
+export function createMathInstanced(s: Instanced) {
+    return { views: instanceMat4Views(s.mesh), p: vec3.create(), q: quat.create() };
+}
+export type MathInstanced = ReturnType<typeof createMathInstanced>;
+
+export function updateMath(s: Instanced, m: MathInstanced, t: number): void {
+    const { mesh, count, base, phase } = s;
+    const { views, p, q } = m;
+    for (let i = 0; i < count; i++) {
+        const o = i * 3;
+        vec3.set(p, base[o], base[o + 1] + Math.sin(t + phase[i]), base[o + 2]);
+        quat.setAxisAngle(q, AXIS, phase[i] + t);
+        mat4.fromRotationTranslationScale(views[i], q, p, ONE);
+    }
+    mesh.instanceMatrix.needsUpdate = true;
+}
+
+export function checksum(s: Instanced): number {
+    const a = s.mesh.instanceMatrix.array;
+    let sum = 0;
+    for (let i = 0; i < a.length; i++) sum += a[i];
+    return sum;
+}

--- a/benches/three/scene-graph.bench.ts
+++ b/benches/three/scene-graph.bench.ts
@@ -1,0 +1,109 @@
+import { assert, bench, group } from '@pmndrs/labs';
+import {
+    FRAME_T,
+    NODES,
+    checksum,
+    createExtended,
+    createMathGraph,
+    createMirror,
+    createSceneGraph,
+    prepareThreeManual,
+    readTransforms,
+    updateExtended,
+    updateMath,
+    updateMirror,
+    updateMirrorViaObject3D,
+    updateThree,
+    updateThreeManual,
+} from './scene-graph';
+
+// Snapshot world matrix checksums after the measured work.
+
+function mathReference(): number {
+    const s = createSceneGraph(NODES);
+    updateMath(s, createMathGraph(s), FRAME_T);
+    return checksum(s);
+}
+
+function threeReference(): number {
+    const s = createSceneGraph(NODES);
+    updateThree(s, FRAME_T);
+    return checksum(s);
+}
+
+group(`three scene graph ${NODES} @three @scene`, () => {
+    bench('three: position/quaternion + updateMatrixWorld', function* () {
+        const s = createSceneGraph(NODES);
+        yield () => updateThree(s, FRAME_T);
+        const sum = checksum(s);
+        assert(sum === mathReference(), 'three and math world matrices differ');
+        return sum;
+    });
+
+    bench('three: matrix.compose + updateMatrixWorld', function* () {
+        const s = createSceneGraph(NODES);
+        prepareThreeManual(s);
+        yield () => updateThreeManual(s, FRAME_T);
+        const sum = checksum(s);
+        assert(sum === mathReference(), 'three (manual) and math world matrices differ');
+        return sum;
+    });
+
+    bench('math: flat propagate into claimed matrices', function* () {
+        const s = createSceneGraph(NODES);
+        const g = createMathGraph(s);
+        yield () => updateMath(s, g, FRAME_T);
+        const sum = checksum(s);
+        assert(sum === threeReference(), 'math and three world matrices differ');
+        return sum;
+    });
+
+    bench('mirror: tuples + root override', function* () {
+        const s = createSceneGraph(NODES);
+        const g = createMirror(s);
+        yield () => updateMirror(s, g, FRAME_T);
+        const sum = checksum(s);
+        assert(sum === threeReference(), 'mirror and three world matrices differ');
+        return sum;
+    });
+
+    bench('extend: records + scene override', function* () {
+        const s = createSceneGraph(NODES);
+        const a = createExtended(s);
+        yield () => updateExtended(s, a, FRAME_T);
+        const sum = checksum(s);
+        assert(sum === threeReference(), 'extend and three world matrices differ');
+        return sum;
+    });
+
+    bench('mirror: written through Object3D views', function* () {
+        const s = createSceneGraph(NODES);
+        const g = createMirror(s);
+        yield () => updateMirrorViaObject3D(s, g, FRAME_T);
+        const sum = checksum(s);
+        assert(sum === threeReference(), 'mirror (views) and three world matrices differ');
+        return sum;
+    });
+
+    bench('three: step + read every position/rotation', function* () {
+        const s = createSceneGraph(NODES);
+        const acc = yield () => {
+            updateThree(s, FRAME_T);
+            return readTransforms(s);
+        };
+        return acc;
+    });
+
+    bench('mirror: step + read every position/rotation', function* () {
+        const s = createSceneGraph(NODES);
+        const g = createMirror(s);
+        const acc = yield () => {
+            updateMirror(s, g, FRAME_T);
+            return readTransforms(s);
+        };
+        const ref = createSceneGraph(NODES);
+        updateThree(ref, FRAME_T);
+        assert(acc === readTransforms(ref), 'mirror reads differ from three');
+        return acc;
+    });
+});

--- a/benches/three/scene-graph.ts
+++ b/benches/three/scene-graph.ts
@@ -1,0 +1,169 @@
+import { Object3D, Quaternion, Scene, Vector3 } from 'three';
+import type { Mat4 } from '../../src/core/mat4';
+import * as mat4 from '../../src/core/mat4';
+import * as quat from '../../src/core/quat';
+import type { Vec3 } from '../../src/core/vec3';
+import * as vec3 from '../../src/core/vec3';
+import * as mulberry32 from '../../src/random/mulberry32';
+import { claimTransform } from '../../src/three';
+import { extend, transformOf, type Transform } from '../../src/three';
+import { claimSubtree, createMirrorGraph, extendTransform, type MirrorGraph } from '../../src/three/mirror';
+
+// Each variant animates a 4-ary tree and propagates its world matrices.
+
+export const NODES = 4096;
+export const FRAME_T = 0.5;
+
+const AXIS: Vec3 = [0.267261, 0.534522, 0.801784];
+const ONE: Vec3 = [1, 1, 1];
+
+export function createSceneGraph(count: number, makeNode: () => Object3D = () => new Object3D()) {
+    const rand = mulberry32.create(42);
+    const scene = new Scene();
+    const objects: Object3D[] = [];
+    const base = new Float64Array(count * 3);
+    const phase = new Float64Array(count);
+    for (let i = 0; i < count; i++) {
+        const object = makeNode();
+        const parent = i === 0 ? scene : objects[(i - 1) >> 2];
+        parent.add(object);
+        objects.push(object);
+        base[i * 3] = (mulberry32.sample(rand) - 0.5) * 4;
+        base[i * 3 + 1] = (mulberry32.sample(rand) - 0.5) * 4;
+        base[i * 3 + 2] = (mulberry32.sample(rand) - 0.5) * 4;
+        phase[i] = mulberry32.sample(rand) * Math.PI * 2;
+    }
+    scene.updateMatrixWorld();
+    return { scene, objects, count, base, phase };
+}
+export type SceneGraph = ReturnType<typeof createSceneGraph>;
+
+const threeAxis = new Vector3(AXIS[0], AXIS[1], AXIS[2]);
+
+export function updateThree(s: SceneGraph, t: number): void {
+    const { scene, objects, count, base, phase } = s;
+    for (let i = 0; i < count; i++) {
+        const o = i * 3;
+        const object = objects[i];
+        object.position.set(base[o], base[o + 1] + Math.sin(t + phase[i]), base[o + 2]);
+        object.quaternion.setFromAxisAngle(threeAxis, phase[i] + t);
+    }
+    scene.updateMatrixWorld();
+}
+
+// Reusable scratch objects avoid allocation and Object3D's Euler synchronization.
+const position = new Vector3();
+const rotation = new Quaternion();
+const scale = new Vector3(1, 1, 1);
+
+export function prepareThreeManual(s: SceneGraph): void {
+    for (const object of s.objects) object.matrixAutoUpdate = false;
+}
+
+export function updateThreeManual(s: SceneGraph, t: number): void {
+    const { scene, objects, count, base, phase } = s;
+    for (let i = 0; i < count; i++) {
+        const o = i * 3;
+        const object = objects[i];
+        position.set(base[o], base[o + 1] + Math.sin(t + phase[i]), base[o + 2]);
+        rotation.setFromAxisAngle(threeAxis, phase[i] + t);
+        object.matrix.compose(position, rotation, scale);
+        object.matrixWorldNeedsUpdate = true;
+    }
+    scene.updateMatrixWorld();
+}
+
+export function createMathGraph(s: SceneGraph) {
+    const locals: Mat4[] = new Array(s.count);
+    const worlds: Mat4[] = new Array(s.count);
+    const parents: Mat4[] = new Array(s.count);
+    for (let i = 0; i < s.count; i++) {
+        const { local, world } = claimTransform(s.objects[i]);
+        locals[i] = local;
+        worlds[i] = world;
+        parents[i] = i === 0 ? s.scene.matrixWorld.elements : worlds[(i - 1) >> 2];
+    }
+    return { locals, worlds, parents, p: vec3.create(), q: quat.create() };
+}
+export type MathGraph = ReturnType<typeof createMathGraph>;
+
+export function updateMath(s: SceneGraph, g: MathGraph, t: number): void {
+    const { count, base, phase } = s;
+    const { locals, worlds, parents, p, q } = g;
+    // Parent indices precede children so one pass propagates the entire tree.
+    for (let i = 0; i < count; i++) {
+        const o = i * 3;
+        vec3.set(p, base[o], base[o + 1] + Math.sin(t + phase[i]), base[o + 2]);
+        quat.setAxisAngle(q, AXIS, phase[i] + t);
+        mat4.fromRotationTranslationScale(locals[i], q, p, ONE);
+        mat4.multiply(worlds[i], parents[i], locals[i]);
+    }
+}
+
+export function checksum(s: SceneGraph): number {
+    let sum = 0;
+    for (let i = 0; i < s.count; i++) {
+        const e = s.objects[i].matrixWorld.elements;
+        for (let k = 0; k < 16; k++) sum += e[k];
+    }
+    return sum;
+}
+
+export function createMirror(s: SceneGraph): MirrorGraph {
+    const g = createMirrorGraph(s.count);
+    for (let i = 0; i < s.count; i++) {
+        const parentWorld = i === 0 ? s.scene.matrixWorld.elements : g.worlds[(i - 1) >> 2];
+        extendTransform(g, s.objects[i], parentWorld);
+    }
+    claimSubtree(g, s.objects[0]);
+    return g;
+}
+
+// The scene update reaches the subtree root and propagates the tuple writes.
+export function updateMirror(s: SceneGraph, g: MirrorGraph, t: number): void {
+    const { scene, count, base, phase } = s;
+    const { positions, rotations } = g;
+    for (let i = 0; i < count; i++) {
+        const o = i * 3;
+        vec3.set(positions[i], base[o], base[o + 1] + Math.sin(t + phase[i]), base[o + 2]);
+        quat.setAxisAngle(rotations[i], AXIS, phase[i] + t);
+    }
+    scene.updateMatrixWorld();
+}
+
+export function updateMirrorViaObject3D(s: SceneGraph, _g: MirrorGraph, t: number): void {
+    const { scene, objects, count, base, phase } = s;
+    for (let i = 0; i < count; i++) {
+        const o = i * 3;
+        const object = objects[i];
+        object.position.set(base[o], base[o + 1] + Math.sin(t + phase[i]), base[o + 2]);
+        object.quaternion.setFromAxisAngle(threeAxis, phase[i] + t);
+    }
+    scene.updateMatrixWorld();
+}
+
+export function readTransforms(s: SceneGraph): number {
+    let acc = 0;
+    for (let i = 0; i < s.count; i++) {
+        const object = s.objects[i];
+        acc += object.position.y + object.rotation.y;
+    }
+    return acc;
+}
+
+// Cache records during setup so the measured loop only writes tuples and propagates.
+export function createExtended(s: SceneGraph): Transform[] {
+    extend(s.scene);
+    return s.objects.map(transformOf);
+}
+
+export function updateExtended(s: SceneGraph, records: Transform[], t: number): void {
+    const { scene, count, base, phase } = s;
+    for (let i = 0; i < count; i++) {
+        const o = i * 3;
+        const record = records[i];
+        vec3.set(record.position, base[o], base[o + 1] + Math.sin(t + phase[i]), base[o + 2]);
+        quat.setAxisAngle(record.rotation, AXIS, phase[i] + t);
+    }
+    scene.updateMatrixWorld();
+}

--- a/benches/three/web/index.html
+++ b/benches/three/web/index.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html>
+<head>
+<meta charset="utf-8" />
+<title>math + three mirror bridge</title>
+<style>
+  html, body { margin: 0; height: 100%; background: #111; color: #eee; font: 12px/1.4 ui-monospace, monospace; }
+  canvas { display: block; position: fixed; inset: 0; }
+  #out { position: fixed; top: 8px; left: 8px; padding: 8px 10px; background: rgba(0,0,0,.7); white-space: pre; z-index: 1; }
+</style>
+</head>
+<body>
+<div id="out">starting…</div>
+<script type="module" src="./main.ts"></script>
+</body>
+</html>

--- a/benches/three/web/main.ts
+++ b/benches/three/web/main.ts
@@ -1,0 +1,162 @@
+// Times scene updates and rendering. Use ?variant=<name> to select a single variant.
+// Results are available in window.__results and the overlay.
+import { BoxGeometry, Mesh, MeshNormalMaterial, PerspectiveCamera, WebGLRenderer } from 'three';
+import type { Object3D } from 'three';
+import {
+    NODES,
+    checksum,
+    createExtended,
+    createMathGraph,
+    createMirror,
+    createSceneGraph,
+    prepareThreeManual,
+    readTransforms,
+    updateExtended,
+    updateMath,
+    updateMirror,
+    updateMirrorViaObject3D,
+    updateThree,
+    updateThreeManual,
+    type SceneGraph,
+} from '../scene-graph';
+
+const WARMUP = 60;
+const FRAMES = 300;
+
+const geometry = new BoxGeometry(0.3, 0.3, 0.3);
+const material = new MeshNormalMaterial();
+const makeNode = (): Object3D => new Mesh(geometry, material);
+
+type Variant = { name: string; setup(s: SceneGraph): (t: number) => number };
+
+const variants: Variant[] = [
+    { name: 'three', setup: (s) => (t) => (updateThree(s, t), 0) },
+    { name: 'three-manual', setup: (s) => (prepareThreeManual(s), (t) => (updateThreeManual(s, t), 0)) },
+    {
+        name: 'math-claimed',
+        setup: (s) => {
+            const g = createMathGraph(s);
+            return (t) => (updateMath(s, g, t), 0);
+        },
+    },
+    {
+        name: 'mirror',
+        setup: (s) => {
+            const g = createMirror(s);
+            return (t) => (updateMirror(s, g, t), 0);
+        },
+    },
+    {
+        name: 'extended',
+        setup: (s) => {
+            const a = createExtended(s);
+            return (t) => (updateExtended(s, a, t), 0);
+        },
+    },
+    {
+        name: 'mirror-object3d',
+        setup: (s) => {
+            const g = createMirror(s);
+            return (t) => (updateMirrorViaObject3D(s, g, t), 0);
+        },
+    },
+    { name: 'three+read', setup: (s) => (t) => (updateThree(s, t), readTransforms(s)) },
+    {
+        name: 'mirror+read',
+        setup: (s) => {
+            const g = createMirror(s);
+            return (t) => (updateMirror(s, g, t), readTransforms(s));
+        },
+    },
+];
+
+const out = document.getElementById('out') as HTMLDivElement;
+const renderer = new WebGLRenderer({ antialias: false, powerPreference: 'high-performance' });
+renderer.setSize(window.innerWidth, window.innerHeight);
+renderer.setPixelRatio(1);
+document.body.appendChild(renderer.domElement);
+const camera = new PerspectiveCamera(60, window.innerWidth / window.innerHeight, 0.1, 200);
+camera.position.set(0, 0, 40);
+
+function median(a: number[]): number {
+    const s = a.slice().sort((x, y) => x - y);
+    return s[s.length >> 1];
+}
+
+type Result = {
+    variant: string;
+    updateMs: number;
+    renderMs: number;
+    cpuMs: number;
+    frameMs: number;
+    checksum: number;
+    read: number;
+};
+const results: Result[] = [];
+(window as unknown as { __results: Result[] }).__results = results;
+
+function raf(): Promise<number> {
+    return new Promise((resolve) => requestAnimationFrame(resolve));
+}
+
+async function runVariant(v: Variant): Promise<Result> {
+    const s = createSceneGraph(NODES, makeNode);
+    // Variants update their own matrices so rendering must not repeat that work.
+    s.scene.matrixWorldAutoUpdate = false;
+    const step = v.setup(s);
+    const updates: number[] = [];
+    const renders: number[] = [];
+    const frames: number[] = [];
+    let t = 0;
+    let read = 0;
+    let last = await raf();
+    for (let f = 0; f < WARMUP + FRAMES; f++) {
+        t += 1 / 60;
+        const t0 = performance.now();
+        read = step(t);
+        const t1 = performance.now();
+        renderer.render(s.scene, camera);
+        const t2 = performance.now();
+        const now = await raf();
+        if (f >= WARMUP) {
+            updates.push(t1 - t0);
+            renders.push(t2 - t1);
+            frames.push(now - last);
+        }
+        last = now;
+    }
+    const r: Result = {
+        variant: v.name,
+        updateMs: median(updates),
+        renderMs: median(renders),
+        cpuMs: median(updates.map((u, i) => u + renders[i])),
+        frameMs: median(frames),
+        checksum: checksum(s),
+        read,
+    };
+    results.push(r);
+    s.scene.clear();
+    return r;
+}
+
+function render(): void {
+    const lines = results.map(
+        (r) =>
+            `${r.variant.padEnd(16)} update ${r.updateMs.toFixed(3).padStart(7)} ms   render ${r.renderMs.toFixed(3).padStart(7)} ms   cpu ${r.cpuMs.toFixed(3).padStart(7)} ms   frame ${r.frameMs.toFixed(2).padStart(6)} ms`,
+    );
+    out.textContent = `scene graph, ${NODES} meshes, medians over ${FRAMES} frames, isolated=${crossOriginIsolated}\n\n${lines.join('\n')}`;
+}
+
+async function main(): Promise<void> {
+    const wanted = new URLSearchParams(location.search).get('variant');
+    const selected = wanted ? variants.filter((v) => v.name === wanted) : variants;
+    for (const v of selected) {
+        out.textContent = `running ${v.name}…`;
+        await runVariant(v);
+        render();
+    }
+    out.textContent += '\n\ndone';
+    console.log('RESULTS', JSON.stringify(results));
+}
+
+main();

--- a/benches/three/web/vite.config.ts
+++ b/benches/three/web/vite.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vite';
+
+// Cross-origin isolation gives performance.now() 5 µs resolution instead of 100 µs.
+export default defineConfig({
+    server: {
+        headers: {
+            'Cross-Origin-Opener-Policy': 'same-origin',
+            'Cross-Origin-Embedder-Policy': 'require-corp',
+        },
+    },
+});

--- a/docs/build.js
+++ b/docs/build.js
@@ -229,6 +229,7 @@ const API_GROUP_DESCRIPTIONS = {
   "math/noise": "Perlin, simplex & worley noise, plus fractal helpers",
   "math/color": "Color & colorspace utilities",
   "math/ik": "Inverse kinematics",
+  "math/three": "Zero-copy bridge to three.js: extend a scene so math drives its transforms",
 };
 
 // the generated full reference lives in a separate file so the README stays a

--- a/docs/modules.ts
+++ b/docs/modules.ts
@@ -4,7 +4,7 @@ import { simplex3d } from 'math/noise'; // perlin / simplex noise
 import { mulberry32 } from 'math/random'; // seeded rng
 import { easing, spring } from 'math/time'; // easings & springs
 import { fabrik2, fabrik3 } from 'math/ik'; // inverse kinematics
-// also: math/color, math/geometry, math/shapes — import only what you use
+// Other modules: math/color, math/geometry, math/shapes and math/three.
 /* SNIPPET_END: modules */
 
 // referenced so this doc module type-checks; not shown in the snippet

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "quaternion",
     "euler",
     "random",
-    "noise"
+    "noise",
+    "three"
   ],
   "license": "MIT",
   "repository": "github:pmndrs/math",
@@ -54,6 +55,10 @@
     "./ik": {
       "import": "./dist/ik/index.js",
       "types": "./dist/src/ik/index.d.ts"
+    },
+    "./three": {
+      "import": "./dist/three/index.js",
+      "types": "./dist/src/three/index.d.ts"
     }
   },
   "files": [
@@ -76,7 +81,7 @@
     "bench": "pnpm --filter benches exec labs",
     "typecheck-docs": "tsc --project docs/tsconfig.json --noEmit",
     "docs": "(cd docs && node ./build.js)",
-    "typedoc": "typedoc --tsconfig ./tsconfig.json --name \"math docs\" --out ./dist-typedoc ./src/index.ts ./src/shapes/index.ts ./src/geometry/index.ts ./src/time/index.ts ./src/random/index.ts ./src/noise/index.ts ./src/color/index.ts ./src/ik/index.ts",
+    "typedoc": "typedoc --tsconfig ./tsconfig.json --name \"math docs\" --out ./dist-typedoc ./src/index.ts ./src/shapes/index.ts ./src/geometry/index.ts ./src/time/index.ts ./src/random/index.ts ./src/noise/index.ts ./src/color/index.ts ./src/ik/index.ts ./src/three/index.ts",
     "build:docs": "pnpm run docs && pnpm run typedoc",
     "release": "pnpm run build && pnpm run test && pnpm run build:examples && pnpm run build:docs && pnpm run build:website"
   },
@@ -85,10 +90,20 @@
     "@biomejs/biome": "^2.5.6",
     "@rollup/plugin-node-resolve": "^16",
     "@rollup/plugin-typescript": "^12",
+    "@types/three": "0.185.4",
     "rollup": "^4",
+    "three": "0.185.1",
     "tslib": "^2.8.1",
     "typedoc": "^0.28.16",
     "typescript": "^5.9.2",
     "vitest": "^3.2.4"
+  },
+  "peerDependencies": {
+    "three": ">=0.166.0"
+  },
+  "peerDependenciesMeta": {
+    "three": {
+      "optional": true
+    }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,9 +17,15 @@ importers:
       '@rollup/plugin-typescript':
         specifier: ^12
         version: 12.3.0(rollup@4.62.4)(tslib@2.8.1)(typescript@5.9.3)
+      '@types/three':
+        specifier: 0.185.4
+        version: 0.185.4
       rollup:
         specifier: ^4
         version: 4.62.4
+      three:
+        specifier: 0.185.1
+        version: 0.185.1
       tslib:
         specifier: ^2.8.1
         version: 2.8.1
@@ -38,13 +44,22 @@ importers:
       '@pmndrs/labs':
         specifier: ^0.9.0
         version: 0.9.0
+      three:
+        specifier: 0.185.1
+        version: 0.185.1
     devDependencies:
+      '@types/three':
+        specifier: 0.185.4
+        version: 0.185.4
       tsx:
         specifier: ^4.21.0
         version: 4.23.6
       typescript:
         specifier: ^5.9.2
         version: 5.9.3
+      vite:
+        specifier: ^7.3.6
+        version: 7.3.6(tsx@4.23.6)(yaml@2.9.0)
 
   docs:
     dependencies:
@@ -149,6 +164,9 @@ packages:
   '@clack/prompts@1.7.0':
     resolution: {integrity: sha512-y7/yvZ2TPAnR9+jnc00klvNNLkJiXFFrQA/hlLCcxA9a2A4zQIOimyFQ9XfwYKiGD1fb5GY8vbKIIgO8d5Tb2A==}
     engines: {node: '>= 20.12.0'}
+
+  '@dimforge/rapier3d-compat@0.12.0':
+    resolution: {integrity: sha512-uekIGetywIgopfD97oDL5PfeezkFpNhwlzlaEYNOA0N6ghdsOvh/HYjSMek5Q2O1PYvRSDFcqFVJl4r4ZBwOow==}
 
   '@esbuild/aix-ppc64@0.28.1':
     resolution: {integrity: sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==}
@@ -513,6 +531,9 @@ packages:
   '@shikijs/vscode-textmate@10.0.2':
     resolution: {integrity: sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==}
 
+  '@tweenjs/tween.js@23.1.3':
+    resolution: {integrity: sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA==}
+
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
@@ -528,8 +549,17 @@ packages:
   '@types/resolve@1.20.2':
     resolution: {integrity: sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==}
 
+  '@types/stats.js@0.17.4':
+    resolution: {integrity: sha512-jIBvWWShCvlBqBNIZt0KAshWpvSjhkwkEu4ZUcASoAvhmrgAUI2t1dXrjSL4xXVLB4FznPrIsX3nKXFl/Dt4vA==}
+
+  '@types/three@0.185.4':
+    resolution: {integrity: sha512-gAsBIC07NIFrxjbf7tH2t71c38uulFfk/RFoC7FNBSjMRAQ8J1x/RBvusX0N5PJouaYFJawXQqfCQ0RKUx/1nA==}
+
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
+
+  '@types/webxr@0.5.24':
+    resolution: {integrity: sha512-h8fgEd/DpoS9CBrjEQXR+dIDraopAEfu4wYVNY2tEPwk60stPWhvZMf4Foo5FakuQ7HFZoa8WceaWFervK2Ovg==}
 
   '@vitest/expect@3.2.7':
     resolution: {integrity: sha512-E8eBXaKibuvH2pSZErOjdVb5vF4PbKYcrnluBTYxEk1l/VhhwZg1kZQsdtjq+CsF5CFydf2Rdkz7jDHKSisi3w==}
@@ -655,6 +685,9 @@ packages:
       picomatch:
         optional: true
 
+  fflate@0.8.3:
+    resolution: {integrity: sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==}
+
   fsevents@2.3.2:
     resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -702,11 +735,14 @@ packages:
     resolution: {integrity: sha512-RCEsPjR+sr0x+AuYp601tKTkgFG4YEPLCzHST3cQ/fhlJkqAkz1L2/Qbp1j9qw5SBwQHFBoW8+hoN5xssOF0Tw==}
     hasBin: true
 
-  math@1.0.0-canary-872f3be9-20260816:
-    resolution: {integrity: sha512-VRuAlhGeSJVDAu18vs2o7FCTxVVP7wUMg3nLeS6XpTfAbezQgPsUgpfWbsAFpT5Gnpd1QKEDqNk9Gy2sKqvjew==}
+  math@1.0.0-canary-37519dcd-20260903:
+    resolution: {integrity: sha512-aul1nzD8ob5wKMKVQqOXe5ufT/xmiTHxObL81J2ImgNRwpRg+r7IeWOQ2WnD5W/cvpZc7gySwXs0YjVpDtahTQ==}
 
   mdurl@2.1.0:
     resolution: {integrity: sha512-1+HBaOx0zi/dQWht8rNv9MYf9qqpqL/kxI0hXImU6Y547zM6Sni8BQibt7ifgMcYtQg41ao3Ivd6cnSM86inpg==}
+
+  meshoptimizer@1.1.1:
+    resolution: {integrity: sha512-oRFNWJRDA/WTrVj7NWvqa5HqE1t9MYDj2VaWirQCzCCrAd2GHrqR/sQezCxiWATPNlKTcRaPRHPJwIRoPBAp5g==}
 
   minimatch@10.2.6:
     resolution: {integrity: sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==}
@@ -787,6 +823,9 @@ packages:
   supports-preserve-symlinks-flag@1.0.0:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
+
+  three@0.185.1:
+    resolution: {integrity: sha512-5aojFCXKwnjBRZvUnt3WFfEcvUJgkN5LlijRFN95hMy8WVkG4I0QNcJE+OuWvuJ0bOdStrbfXn0pkd6/QyiAlg==}
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
@@ -969,6 +1008,8 @@ snapshots:
       fast-string-width: 3.0.2
       fast-wrap-ansi: 0.2.2
       sisteransi: 1.0.5
+
+  '@dimforge/rapier3d-compat@0.12.0': {}
 
   '@esbuild/aix-ppc64@0.28.1':
     optional: true
@@ -1192,6 +1233,8 @@ snapshots:
 
   '@shikijs/vscode-textmate@10.0.2': {}
 
+  '@tweenjs/tween.js@23.1.3': {}
+
   '@types/chai@5.2.3':
     dependencies:
       '@types/deep-eql': 4.0.2
@@ -1207,7 +1250,20 @@ snapshots:
 
   '@types/resolve@1.20.2': {}
 
+  '@types/stats.js@0.17.4': {}
+
+  '@types/three@0.185.4':
+    dependencies:
+      '@dimforge/rapier3d-compat': 0.12.0
+      '@tweenjs/tween.js': 23.1.3
+      '@types/stats.js': 0.17.4
+      '@types/webxr': 0.5.24
+      fflate: 0.8.3
+      meshoptimizer: 1.1.1
+
   '@types/unist@3.0.3': {}
+
+  '@types/webxr@0.5.24': {}
 
   '@vitest/expect@3.2.7':
     dependencies:
@@ -1342,6 +1398,8 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.5
 
+  fflate@0.8.3: {}
+
   fsevents@2.3.2:
     optional: true
 
@@ -1352,7 +1410,7 @@ snapshots:
 
   gpucat@https://codeload.github.com/isaac-mason/gpucat/tar.gz/17fdd24630322bfb3a3f01719de0d3bea47909c4:
     dependencies:
-      math: 1.0.0-canary-872f3be9-20260816
+      math: 1.0.0-canary-37519dcd-20260903
 
   hasown@2.0.4:
     dependencies:
@@ -1387,9 +1445,11 @@ snapshots:
       punycode.js: 2.3.1
       uc.micro: 2.1.0
 
-  math@1.0.0-canary-872f3be9-20260816: {}
+  math@1.0.0-canary-37519dcd-20260903: {}
 
   mdurl@2.1.0: {}
+
+  meshoptimizer@1.1.1: {}
 
   minimatch@10.2.6:
     dependencies:
@@ -1480,6 +1540,8 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
+  three@0.185.1: {}
+
   tinybench@2.9.0: {}
 
   tinyexec@0.3.2: {}
@@ -1554,6 +1616,19 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
       tsx: 4.23.12
+      yaml: 2.9.0
+
+  vite@7.3.6(tsx@4.23.6)(yaml@2.9.0):
+    dependencies:
+      esbuild: 0.28.1
+      fdir: 6.5.0(picomatch@4.0.5)
+      picomatch: 4.0.5
+      postcss: 8.5.25
+      rollup: 4.62.4
+      tinyglobby: 0.2.17
+    optionalDependencies:
+      fsevents: 2.3.3
+      tsx: 4.23.6
       yaml: 2.9.0
 
   vitest@3.2.7(tsx@4.23.12)(yaml@2.9.0):

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -18,7 +18,9 @@ export default {
         './src/noise/index.ts',
         './src/color/index.ts',
         './src/ik/index.ts',
+        './src/three/index.ts',
     ],
+    external: ['three'],
     output: {
         dir: 'dist',
         format: 'es',

--- a/skills/math/SKILL.md
+++ b/skills/math/SKILL.md
@@ -51,6 +51,7 @@ export function getWorldPosition(out: Vec3, world: World, i: number): Vec3 { /* 
 - Compare squared distances; reach for `squaredLength` / `squaredDistance` over their square-rooted pairs.
 - Integers in the range [-2^30, 2^30) are stored in the pointer itself (V8 Smi), with no heap object. Use them for indices, handles, packed IDs, bitmasks, and counts.
 - Where possible avoid plain array element kind transitions (small integers, doubles, array with holes). Especially avoid unnecessary SMI or PACKED_DOUBLE to holey transitions when holey arrays are not desired.
+- **Keep hot-path storage consistent.** Mixing plain arrays and typed arrays in the same math function can make element accesses polymorphic and reduce optimization. The tuple types help enforce this consistency. Casting a `Float32Array` to `Vec3` doesn't change its runtime storage. Marshal at boundaries when needed to keep the hot path monomorphic.
 - Don't assume a typed array is faster. A packed plain array is already unboxed and can still grow. Typed arrays buy footprint, a fixed layout, and zero-copy interop with workers, Wasm, and the GPU; they cost a capacity fixed up front and, for `Float32Array`, a narrowing conversion on every write. Choose one for interop or memory, not on a hunch about speed.
 - In a **library**, annotate module-level factory calls `/* @__PURE__ */` so a consumer's bundler can drop the scratch when the function is tree-shaken out. Application code does not need it.
 
@@ -60,81 +61,57 @@ Deliver the implementation with its assumptions, complexity, edge cases, and foc
 
 Marshal in, compute, marshal out — and allocate on neither crossing. Keep the scratch `math` types at module scope, fill them from the other library's values, run the algorithm as plain `math` calls, then write the results back. The seam is a few lines at each end of a function; everything between them is flat data.
 
-- **A `Float32Array` is not a `Vec3`.** The tuple types don't accept one, and casting past that gets you a value the rest of the codebase can't rely on. Marshal across the boundary instead.
 - **Marshal with whatever writes into memory you already own.** For flat buffers — an instanced attribute, a packed particle array — that's `vec3.fromBuffer(out, buffer, i * 3)` and `vec3.toBuffer(buffer, v, i * 3)` (also on `vec2`, `vec4`, `quat`), or `buffer.set(m, i * 16)` for a whole matrix, since `TypedArray.set` takes any array-like.
 - **State that crosses a worker, Wasm, or GPU boundary lives in a typed array from the start.** A plain-array `Vec3` can't be transferred or shared, so back the long-lived data with `Float32Array` / `SharedArrayBuffer` at creation and marshal at the edges.
 
 ### three.js
 
-`Vector3`, `Quaternion`, `Matrix4`, and `Euler` all marshal through `toArray(target)` and `fromArray(source)`, and the component order matches `math`'s in every case. Always pass your scratch to `toArray` — called bare, it allocates a fresh array.
+Choose the integration based on who drives the hot path:
 
-**Orbit camera.** The camera's state is a `Spherical` and a target the caller owns; three only ever sees the resulting position.
+- **Extend** when math updates many objects each frame. Use `extend(scene)` from `math/three` and cached transform records.
+- **Don't extend** when mostly using Three's transform API, frequently rebuilding the hierarchy, or only needing occasional math. Keep stock objects and marshal through reusable scratch.
+
+The `math/three` helpers for matrices, instancing, attributes, and culling work either way. See `API.md` for their usage. Instance matrix views use float32 storage, so keep simulation state separate.
+
+**What gets faster.** The tuple path can substantially speed up CPU transform updates by eliminating copies between math and Three, deferring quaternion-to-Euler conversion until Euler angles are read, and composing local matrices and propagating world matrices in a flat pass. Gains depend on the workload, so compare representative frames.
+
+**Use the hot path.** For objects already in `scene`, extend and cache records at setup. Mutate their tuples directly in the loop. `rotation` is a quaternion.
 
 ```ts
-import { spherical, vec3 } from 'math';
-import type { Camera } from 'three';
+import { quat, vec3, type Vec3 } from 'math';
+import { extend, transformOf } from 'math/three';
 
-const MIN_RADIUS = 1;
-const MAX_RADIUS = 100;
+extend(scene);
+const transforms = objects.map(transformOf);
 
-export function createOrbit() {
-    return { target: vec3.create(), orbit: spherical.fromValues(10, 0, Math.PI / 3) };
-}
-export type Orbit = ReturnType<typeof createOrbit>;
-
-const _orbit_position = vec3.create();
-
-/** Apply a drag in radians and a zoom factor, then place the camera. */
-export function updateOrbit(camera: Camera, orbit: Orbit, dragX: number, dragY: number, zoom: number): void {
-    const s = orbit.orbit;
-
-    s[0] = Math.min(MAX_RADIUS, Math.max(MIN_RADIUS, s[0] * zoom));
-    s[1] -= dragX;
-    s[2] -= dragY;
-    spherical.makeSafe(s, s); // keeps phi off the poles, where the frame degenerates
-
-    vec3.add(_orbit_position, spherical.toVec3(_orbit_position, s), orbit.target);
-
-    camera.position.fromArray(_orbit_position);
-    camera.lookAt(orbit.target[0], orbit.target[1], orbit.target[2]);
+function step(velocities: Vec3[], delta: number): void {
+    for (let i = 0; i < transforms.length; i++) {
+        const t = transforms[i];
+        vec3.scaleAndAdd(t.position, t.position, velocities[i], delta);
+        quat.rotateY(t.rotation, t.rotation, delta);
+    }
 }
 ```
 
-**Camera-relative character move.** Takes the yaw straight from that orbit state, so stick-forward means away-from-camera.
+Rendering propagates matrices automatically. Call `propagate(scene)` once before queries that need current world matrices. Cache records only while objects stay extended.
+
+**What costs more.** Extending allocates records and replaces transform properties with views. Adding, removing, or reparenting objects requires rebuilding the flat traversal. Three-style property access goes through accessors, and Euler reads check for quaternion changes and derive angles when needed. Heavy use of these paths can offset the tuple gains. Custom `updateMatrixWorld` overrides retain their own traversal.
+
+**Without extension.** This performs the same update on stock Three objects. Allocate scratch once, marshal in, compute, and marshal out. Always pass a target to `toArray` to avoid allocation.
 
 ```ts
 import { quat, vec3, type Vec3 } from 'math';
 import type { Object3D } from 'three';
 
-const UP: Vec3 = [0, 1, 0];
-const TURN_RATE = 15;
-const DEADZONE_SQ = 0.01;
+const _step_position = vec3.create();
+const _step_rotation = quat.create();
 
-const _move_yaw = quat.create();
-const _move_facing = quat.create();
-const _move_rotation = quat.create();
-const _move_position = vec3.create();
-const _move_direction = vec3.create();
-
-/** Move `character` by `inputX` / `inputZ` (a stick, in [-1, 1]) relative to a camera at `yaw`. */
-export function moveCharacter(character: Object3D, inputX: number, inputZ: number, yaw: number, speed: number, delta: number): void {
-    vec3.set(_move_direction, inputX, 0, inputZ);
-    if (vec3.squaredLength(_move_direction) < DEADZONE_SQ) return; // idle: leave the facing alone
-
-    // swing the stick into camera space, then step along it
-    quat.setAxisAngle(_move_yaw, UP, yaw);
-    vec3.transformQuat(_move_direction, _move_direction, _move_yaw);
-    vec3.normalize(_move_direction, _move_direction);
-
-    character.position.toArray(_move_position);
-    vec3.scaleAndAdd(_move_position, _move_position, _move_direction, speed * delta);
-
-    // turn toward travel, rather than snapping
-    character.quaternion.toArray(_move_rotation);
-    quat.setAxisAngle(_move_facing, UP, Math.atan2(_move_direction[0], _move_direction[2]));
-    quat.slerp(_move_rotation, _move_rotation, _move_facing, 1 - TURN_RATE ** -delta);
-
-    character.position.fromArray(_move_position);
-    character.quaternion.fromArray(_move_rotation);
+function step(object: Object3D, velocity: Vec3, delta: number): void {
+    object.position.toArray(_step_position);
+    object.quaternion.toArray(_step_rotation);
+    vec3.scaleAndAdd(_step_position, _step_position, velocity, delta);
+    quat.rotateY(_step_rotation, _step_rotation, delta);
+    object.position.fromArray(_step_position);
+    object.quaternion.fromArray(_step_rotation);
 }
 ```

--- a/src/three/bridge.ts
+++ b/src/three/bridge.ts
@@ -1,0 +1,133 @@
+import type {
+    BufferAttribute,
+    Camera,
+    InstancedMesh,
+    Matrix4,
+    Object3D,
+    Quaternion,
+    Sphere as ThreeSphere,
+    Vector3,
+} from 'three';
+import { MathUtils } from 'three';
+
+// three's normalize helpers are typed without Uint8ClampedArray, which BufferAttribute allows
+type NormalizableArray = Parameters<typeof MathUtils.denormalize>[1];
+import type { Mat4 } from '../core/mat4';
+import type { Quat } from '../core/quat';
+import type { Vec3 } from '../core/vec3';
+import * as vec3 from '../core/vec3';
+import type { Frustum } from '../shapes/frustum';
+import * as frustum from '../shapes/frustum';
+import type { Sphere } from '../shapes/sphere';
+
+// Three's column-major matrix tuples and attribute arrays can be used directly by math.
+
+/** A three Matrix4's storage, usable as a math Mat4 with no cast and no copy */
+export function mat4Of(m: Matrix4): Mat4 {
+    return m.elements;
+}
+
+/**
+ * Disables automatic transform updates. The caller owns the local and world matrices
+ * used by rendering and raycasting. Call once at setup.
+ */
+export function claimTransform(object: Object3D): { local: Mat4; world: Mat4 } {
+    object.matrixAutoUpdate = false;
+    object.matrixWorldAutoUpdate = false;
+    return { local: object.matrix.elements, world: object.matrixWorld.elements };
+}
+
+/**
+ * Allocates one Mat4 view per instance over the upload buffer. Call once at setup and set
+ * `instanceMatrix.needsUpdate` after writing. Keep simulation state separate because reads
+ * through these views are rounded to float32.
+ */
+export function instanceMat4Views(mesh: InstancedMesh): Mat4[] {
+    const array = mesh.instanceMatrix.array;
+    const count = mesh.count;
+    const views: Mat4[] = new Array(count);
+    for (let i = 0; i < count; i++) {
+        const offset = i * 16;
+        views[i] = array.subarray(offset, offset + 16) as unknown as Mat4;
+    }
+    return views;
+}
+
+/** Reads vertex `index` of a 3-component attribute into a Vec3, denormalizing like `getX` does. */
+export function vec3FromAttribute(out: Vec3, attribute: BufferAttribute, index: number): Vec3 {
+    const array = attribute.array;
+    const offset = index * 3;
+    if (attribute.normalized) {
+        const kind = array as NormalizableArray;
+        out[0] = MathUtils.denormalize(array[offset], kind);
+        out[1] = MathUtils.denormalize(array[offset + 1], kind);
+        out[2] = MathUtils.denormalize(array[offset + 2], kind);
+        return out;
+    }
+    return vec3.fromBuffer(out, array, offset);
+}
+
+/** Writes a Vec3 into vertex `index` of a 3-component attribute, normalizing like `setXYZ` does. Set `needsUpdate` afterwards. */
+export function vec3ToAttribute(attribute: BufferAttribute, a: Vec3, index: number): void {
+    const array = attribute.array;
+    const offset = index * 3;
+    if (attribute.normalized) {
+        const kind = array as NormalizableArray;
+        array[offset] = MathUtils.normalize(a[0], kind);
+        array[offset + 1] = MathUtils.normalize(a[1], kind);
+        array[offset + 2] = MathUtils.normalize(a[2], kind);
+        return;
+    }
+    vec3.toBuffer(array, a, offset);
+}
+
+/**
+ * Extracts a frustum for a camera using WebGL depth in [-1, 1].
+ * Call after `camera.updateMatrixWorld()` to read the current view matrix.
+ */
+export function frustumFromCamera(out: Frustum, camera: Camera): Frustum {
+    return frustum.setFromViewProjectionMatrixNO(out, camera.projectionMatrix.elements, camera.matrixWorldInverse.elements);
+}
+
+/**
+ * Transforms a local bounding sphere to world space. Scales the radius by the largest
+ * axis scale, matching three's `Sphere.applyMatrix4`.
+ */
+export function sphereToWorld(out: Sphere, local: ThreeSphere, world: Mat4): Sphere {
+    const c = out.center;
+    c[0] = local.center.x;
+    c[1] = local.center.y;
+    c[2] = local.center.z;
+    vec3.transformMat4(c, c, world);
+    const sx = world[0] * world[0] + world[1] * world[1] + world[2] * world[2];
+    const sy = world[4] * world[4] + world[5] * world[5] + world[6] * world[6];
+    const sz = world[8] * world[8] + world[9] * world[9] + world[10] * world[10];
+    out.radius = local.radius * Math.sqrt(Math.max(sx, sy, sz));
+    return out;
+}
+
+// Copy helpers for stock three vectors and quaternions.
+
+export function vec3FromVector3(out: Vec3, v: Vector3): Vec3 {
+    out[0] = v.x;
+    out[1] = v.y;
+    out[2] = v.z;
+    return out;
+}
+
+export function vec3ToVector3(out: Vector3, a: Vec3): Vector3 {
+    return out.set(a[0], a[1], a[2]);
+}
+
+export function quatFromQuaternion(out: Quat, q: Quaternion): Quat {
+    out[0] = q.x;
+    out[1] = q.y;
+    out[2] = q.z;
+    out[3] = q.w;
+    return out;
+}
+
+/** Fires the quaternion's change callback once. On an Object3D's quaternion that re-derives `rotation`. */
+export function quatToQuaternion(out: Quaternion, q: Quat): Quaternion {
+    return out.set(q[0], q[1], q[2], q[3]);
+}

--- a/src/three/extend.ts
+++ b/src/three/extend.ts
@@ -1,0 +1,324 @@
+import { Object3D } from 'three';
+import type { Vector3 } from 'three';
+import type { Mat4 } from '../core/mat4';
+import * as mat4 from '../core/mat4';
+import type { Quat } from '../core/quat';
+import type { Vec3 } from '../core/vec3';
+import { installViews, releaseViews } from './mirror';
+
+// extend(scene) makes a whole scene math-backed in one call.
+//
+// Every object gets a Transform record: tuples for position, rotation and scale, plus the
+// object's own matrix storage. Views over the tuples replace the object's transform
+// properties (see mirror.ts), so three's API keeps working and reads the same numbers math
+// writes. The scene's `updateMatrixWorld` is overridden so the renderer's per-frame call runs
+// one flat parents-first pass instead of a recursive walk. Objects added later join from
+// three's `childadded` event, so loaders, clone(), react-three-fiber and friends are covered
+// automatically. Objects that leave the scene are released on the next pass. Nodes that are
+// not extended (released by hand) still get three's own per-node update inside the same pass.
+//
+// Honors per-node `matrixAutoUpdate`, `matrixWorldAutoUpdate` and `pivot`, and clears
+// `matrixWorldNeedsUpdate`, the same as three's `updateMatrixWorld` on the renderer path.
+//
+// Classes that extend `updateMatrixWorld` (Camera computes matrixWorldInverse, SkinnedMesh
+// its bindMatrixInverse, TransformControls its gizmo, user subclasses whatever they like)
+// keep their behavior. The pass delegates to their own method and skips their subtree,
+// which that method walks itself. Their records and views still work, because three's
+// `updateMatrix` composes from the views.
+
+/** The math side of an extended object. Stable for as long as the object stays extended. */
+export type Transform = {
+    position: Vec3;
+    rotation: Quat;
+    scale: Vec3;
+    /** aliases `object.matrix.elements` */
+    local: Mat4;
+    /** aliases `object.matrixWorld.elements` */
+    world: Mat4;
+};
+
+type Pivoted = Object3D & { pivot?: Vector3 | null };
+type ChildEvent = { child: Object3D };
+
+// object to its record, and to the scene that owns its views (null for standalone objects)
+const records = new WeakMap<Object3D, Transform>();
+const owners = new WeakMap<Object3D, Graph | null>();
+const graphs = new WeakMap<Object3D, Graph>();
+
+function createGraph(root: Object3D) {
+    const g = {
+        root,
+        version: 0,
+        // every extended object under the root
+        members: new Set<Object3D>(),
+        // every node in the scene reports hierarchy changes, extended or not, until it leaves
+        tracked: new Set<Object3D>(),
+        // flat traversal of the scene, rebuilt lazily after any structural change. The pass
+        // reads parallel arrays by traversal index, with the tuple references copied out of
+        // the records at rebuild, so the per-node work touches no record and no lookup.
+        orderDirty: true,
+        orderObjects: [] as Object3D[],
+        orderParents: [] as Mat4[],
+        orderPositions: [] as Vec3[],
+        orderRotations: [] as Quat[],
+        orderScales: [] as Vec3[],
+        orderLocals: [] as Mat4[],
+        orderWorlds: [] as Mat4[],
+        // per order entry: 0 extended, 1 delegate to the object's own updateMatrixWorld, 2 plain three
+        orderKinds: new Int32Array(0),
+        // per order entry, the index just past its last descendant, to skip a delegated subtree
+        orderEnds: new Int32Array(0),
+        orderCount: 0,
+        onChildAdded: null as unknown as (event: ChildEvent) => void,
+        onChildRemoved: null as unknown as () => void,
+    };
+    g.onChildAdded = (event) => {
+        event.child.traverse((node) => {
+            extendNode(g, node);
+        });
+    };
+    g.onChildRemoved = () => {
+        g.orderDirty = true;
+    };
+    return g;
+}
+type Graph = ReturnType<typeof createGraph>;
+
+/** The Transform of an extended object. Throws for an object that is not extended. */
+export function transformOf(object: Object3D): Transform {
+    const record = records.get(object);
+    if (record === undefined) throw new Error(`object "${object.name || object.type}" is not extended`);
+    return record;
+}
+
+function createRecord(object: Object3D): Transform {
+    const record: Transform = {
+        position: [object.position.x, object.position.y, object.position.z],
+        rotation: [object.quaternion.x, object.quaternion.y, object.quaternion.z, object.quaternion.w],
+        scale: [object.scale.x, object.scale.y, object.scale.z],
+        local: object.matrix.elements,
+        world: object.matrixWorld.elements,
+    };
+    installViews(object, record.position, record.rotation, record.scale);
+    records.set(object, record);
+    return record;
+}
+
+/**
+ * Extends one object on its own, such as a camera outside the scene tree. Its own
+ * `updateMatrixWorld` composes from the views. Stays extended until `release`.
+ */
+export function extendObject(object: Object3D): Transform {
+    const existing = records.get(object);
+    if (existing !== undefined) return existing;
+    owners.set(object, null);
+    return createRecord(object);
+}
+
+function extendNode(g: Graph, object: Object3D): void {
+    g.orderDirty = true;
+    if (owners.get(object) === g) return;
+    if (records.has(object)) {
+        // owned elsewhere, standalone or another scene: take over, keeping the same record
+        const previous = owners.get(object);
+        if (previous != null) previous.members.delete(object);
+        owners.set(object, g);
+    } else {
+        owners.set(object, g);
+        createRecord(object);
+    }
+    g.members.add(object);
+    track(g, object);
+}
+
+function track(g: Graph, object: Object3D): void {
+    if (g.tracked.has(object)) return;
+    g.tracked.add(object);
+    object.addEventListener('childadded', g.onChildAdded);
+    object.addEventListener('childremoved', g.onChildRemoved);
+}
+
+function untrack(g: Graph, object: Object3D): void {
+    if (!g.tracked.delete(object)) return;
+    object.removeEventListener('childadded', g.onChildAdded);
+    object.removeEventListener('childremoved', g.onChildRemoved);
+}
+
+/**
+ * Gives an object its plain three transform back. An object that stays in an extended scene
+ * keeps reporting hierarchy changes, so children added under it later are still extended.
+ */
+export function release(object: Object3D): void {
+    if (!records.has(object)) return;
+    const g = owners.get(object);
+    if (g != null) {
+        g.members.delete(object);
+        g.orderDirty = true;
+    }
+    owners.delete(object);
+    records.delete(object);
+    releaseViews(object);
+}
+
+// plain nodes compose through three, so their tuple entries are never read
+const unusedPosition: Vec3 = [0, 0, 0];
+const unusedRotation: Quat = [0, 0, 0, 1];
+const unusedScale: Vec3 = [1, 1, 1];
+
+function rebuildOrder(g: Graph): void {
+    const { root, orderObjects, orderParents, orderPositions, orderRotations, orderScales, orderLocals, orderWorlds } = g;
+    const visited = new Set<Object3D>();
+    const kinds: number[] = [];
+    const ends: number[] = [];
+    let count = 0;
+    // parents-first, every node in the scene, extended or not
+    const visit = (object: Object3D, parentWorld: Mat4): void => {
+        const k = count++;
+        orderObjects[k] = object;
+        orderParents[k] = parentWorld;
+        const record = owners.get(object) === g ? records.get(object) : undefined;
+        if (record !== undefined) {
+            orderPositions[k] = record.position;
+            orderRotations[k] = record.rotation;
+            orderScales[k] = record.scale;
+            orderLocals[k] = record.local;
+            orderWorlds[k] = record.world;
+            kinds[k] = object.updateMatrixWorld === Object3D.prototype.updateMatrixWorld ? 0 : 1;
+        } else {
+            orderPositions[k] = unusedPosition;
+            orderRotations[k] = unusedRotation;
+            orderScales[k] = unusedScale;
+            orderLocals[k] = object.matrix.elements;
+            orderWorlds[k] = object.matrixWorld.elements;
+            kinds[k] = object.updateMatrixWorld === Object3D.prototype.updateMatrixWorld ? 2 : 1;
+        }
+        visited.add(object);
+        track(g, object);
+        const world = object.matrixWorld.elements;
+        const children = object.children;
+        for (let i = 0; i < children.length; i++) visit(children[i], world);
+        ends[k] = count;
+    };
+    const rootWorld = root.matrixWorld.elements;
+    for (let i = 0; i < root.children.length; i++) visit(root.children[i], rootWorld);
+    orderObjects.length = count;
+    orderParents.length = count;
+    orderPositions.length = count;
+    orderRotations.length = count;
+    orderScales.length = count;
+    orderLocals.length = count;
+    orderWorlds.length = count;
+    if (g.orderKinds.length !== count) {
+        g.orderKinds = new Int32Array(count);
+        g.orderEnds = new Int32Array(count);
+    }
+    for (let k = 0; k < count; k++) {
+        g.orderKinds[k] = kinds[k];
+        g.orderEnds[k] = ends[k];
+    }
+    g.orderCount = count;
+    // anything tracked that is no longer under the root has left the scene
+    for (const object of g.tracked) {
+        if (visited.has(object)) continue;
+        if (owners.get(object) === g) release(object);
+        untrack(g, object);
+    }
+    g.orderDirty = false;
+}
+
+function applyPivot(local: Mat4, pivot: Vector3): void {
+    // the same arithmetic as three's Object3D.updateMatrix
+    const px = pivot.x;
+    const py = pivot.y;
+    const pz = pivot.z;
+    local[12] += px - local[0] * px - local[4] * py - local[8] * pz;
+    local[13] += py - local[1] * px - local[5] * py - local[9] * pz;
+    local[14] += pz - local[2] * px - local[6] * py - local[10] * pz;
+}
+
+/** One flat pass over the scene: compose extended nodes from their records, propagate world matrices. */
+export function propagate(scene: Object3D): void {
+    const g = graphs.get(scene);
+    if (g === undefined) throw new Error('scene is not extended');
+    run(g);
+}
+
+function run(g: Graph): void {
+    if (g.orderDirty) rebuildOrder(g);
+    g.version++;
+    const { orderObjects, orderParents, orderPositions, orderRotations, orderScales, orderLocals, orderWorlds } = g;
+    const { orderKinds, orderEnds, orderCount } = g;
+    for (let k = 0; k < orderCount; ) {
+        const object = orderObjects[k] as Pivoted;
+        const kind = orderKinds[k];
+        if (kind === 1) {
+            // a subclass with its own updateMatrixWorld: let it run and walk its subtree
+            object.updateMatrixWorld(true);
+            k = orderEnds[k];
+            continue;
+        }
+        if (object.matrixAutoUpdate) {
+            if (kind === 0) {
+                const local = orderLocals[k];
+                mat4.fromRotationTranslationScale(local, orderRotations[k], orderPositions[k], orderScales[k]);
+                const pivot = object.pivot;
+                if (pivot != null) applyPivot(local, pivot);
+            } else {
+                object.updateMatrix();
+            }
+        }
+        if (object.matrixWorldAutoUpdate) mat4.multiply(orderWorlds[k], orderParents[k], orderLocals[k]);
+        object.matrixWorldNeedsUpdate = false;
+        k++;
+    }
+}
+
+function updateSelf(root: Object3D): void {
+    if (root.matrixAutoUpdate) root.updateMatrix();
+    if (root.matrixWorldAutoUpdate) {
+        if (root.parent === null) root.matrixWorld.copy(root.matrix);
+        else root.matrixWorld.multiplyMatrices(root.parent.matrixWorld, root.matrix);
+    }
+    root.matrixWorldNeedsUpdate = false;
+}
+
+/**
+ * Extends every object under `scene` and makes the scene's own update entry points run the
+ * flat pass. Returns the scene. The scene itself keeps plain three transforms. Calling it on
+ * an already extended scene is a no-op.
+ */
+export function extend<T extends Object3D>(scene: T): T {
+    if (graphs.has(scene)) return scene;
+    const g = createGraph(scene);
+    graphs.set(scene, g);
+    scene.updateMatrixWorld = () => {
+        updateSelf(scene);
+        run(g);
+    };
+    scene.updateWorldMatrix = (updateParents?: boolean, updateChildren?: boolean) => {
+        if (updateParents === true && scene.parent !== null) scene.parent.updateWorldMatrix(true, false);
+        updateSelf(scene);
+        if (updateChildren === true) run(g);
+    };
+    scene.addEventListener('childadded', g.onChildAdded);
+    scene.addEventListener('childremoved', g.onChildRemoved);
+    for (let i = 0; i < scene.children.length; i++) {
+        scene.children[i].traverse((node) => {
+            extendNode(g, node);
+        });
+    }
+    return scene;
+}
+
+/** Undoes extend: every object under the scene gets plain transforms back, the scene its own methods. */
+export function unextend(scene: Object3D): void {
+    const g = graphs.get(scene);
+    if (g === undefined) return;
+    for (const object of g.members) release(object);
+    for (const object of g.tracked) untrack(g, object);
+    scene.removeEventListener('childadded', g.onChildAdded);
+    scene.removeEventListener('childremoved', g.onChildRemoved);
+    delete (scene as Partial<Object3D>).updateMatrixWorld;
+    delete (scene as Partial<Object3D>).updateWorldMatrix;
+    graphs.delete(scene);
+}

--- a/src/three/index.ts
+++ b/src/three/index.ts
@@ -1,0 +1,15 @@
+export type { Transform } from './extend';
+export { extend, extendObject, propagate, release, transformOf, unextend } from './extend';
+export {
+    claimTransform,
+    frustumFromCamera,
+    instanceMat4Views,
+    mat4Of,
+    quatFromQuaternion,
+    quatToQuaternion,
+    sphereToWorld,
+    vec3FromAttribute,
+    vec3FromVector3,
+    vec3ToAttribute,
+    vec3ToVector3,
+} from './bridge';

--- a/src/three/mirror.ts
+++ b/src/three/mirror.ts
@@ -1,0 +1,272 @@
+import { Euler, type Object3D, Quaternion, Vector3 } from 'three';
+import type { Mat4 } from '../core/mat4';
+import * as mat4 from '../core/mat4';
+import type { Quat } from '../core/quat';
+import type { Vec3 } from '../core/vec3';
+
+// Object3D transform views share math tuples. Euler angles are derived on demand.
+// The fixed subtree pass does not support pivots or per-node manual matrices.
+
+type Vec3View = Vector3 & { readonly t: Vec3 };
+type QuatView = Quaternion & { readonly t: Quat };
+type LazyEuler = Euler & {
+    __x: number;
+    __y: number;
+    __z: number;
+    __order: Euler['order'];
+    // Quaternion values corresponding to the stored Euler angles.
+    sx: number;
+    sy: number;
+    sz: number;
+    sw: number;
+    readonly q: QuatView;
+};
+
+// Shared prototypes bypass constructors that would write through the tuple accessors.
+
+function Vec3ViewCtor(this: Vec3View, t: Vec3) {
+    (this as { t: Vec3 }).t = t;
+}
+Vec3ViewCtor.prototype = Object.create(Vector3.prototype, {
+    constructor: { value: Vector3 },
+    x: {
+        get(this: Vec3View) {
+            return this.t[0];
+        },
+        set(this: Vec3View, v: number) {
+            this.t[0] = v;
+        },
+    },
+    y: {
+        get(this: Vec3View) {
+            return this.t[1];
+        },
+        set(this: Vec3View, v: number) {
+            this.t[1] = v;
+        },
+    },
+    z: {
+        get(this: Vec3View) {
+            return this.t[2];
+        },
+        set(this: Vec3View, v: number) {
+            this.t[2] = v;
+        },
+    },
+});
+const Vec3ViewClass = Vec3ViewCtor as unknown as new (t: Vec3) => Vec3View;
+
+function QuatViewCtor(this: QuatView, t: Quat) {
+    (this as { isQuaternion: boolean }).isQuaternion = true;
+    (this as { t: Quat }).t = t;
+}
+QuatViewCtor.prototype = Object.create(Quaternion.prototype, {
+    constructor: { value: Quaternion },
+    _x: {
+        get(this: QuatView) {
+            return this.t[0];
+        },
+        set(this: QuatView, v: number) {
+            this.t[0] = v;
+        },
+    },
+    _y: {
+        get(this: QuatView) {
+            return this.t[1];
+        },
+        set(this: QuatView, v: number) {
+            this.t[1] = v;
+        },
+    },
+    _z: {
+        get(this: QuatView) {
+            return this.t[2];
+        },
+        set(this: QuatView, v: number) {
+            this.t[2] = v;
+        },
+    },
+    _w: {
+        get(this: QuatView) {
+            return this.t[3];
+        },
+        set(this: QuatView, v: number) {
+            this.t[3] = v;
+        },
+    },
+});
+const QuatViewClass = QuatViewCtor as unknown as new (t: Quat) => QuatView;
+
+// Preserve explicit angles until the quaternion changes. Re-deriving an equivalent Euler
+// can change its angles and reverse subsequent component increments.
+function eulerStale(e: LazyEuler): boolean {
+    const t = e.q.t;
+    return t[0] !== e.sx || t[1] !== e.sy || t[2] !== e.sz || t[3] !== e.sw;
+}
+
+function snapshotEuler(e: LazyEuler): void {
+    const t = e.q.t;
+    e.sx = t[0];
+    e.sy = t[1];
+    e.sz = t[2];
+    e.sw = t[3];
+}
+
+function deriveEuler(e: LazyEuler): void {
+    // Snapshot first because derivation writes through the Euler accessors.
+    snapshotEuler(e);
+    Euler.prototype.setFromQuaternion.call(e, e.q, undefined, false);
+}
+
+function eulerComponent(field: '__x' | '__y' | '__z'): PropertyDescriptor {
+    return {
+        get(this: LazyEuler) {
+            if (eulerStale(this)) deriveEuler(this);
+            return this[field];
+        },
+        set(this: LazyEuler, v: number) {
+            if (eulerStale(this)) deriveEuler(this);
+            this[field] = v;
+        },
+    };
+}
+
+function LazyEulerCtor(this: LazyEuler, q: QuatView, source: Euler) {
+    const self = this as unknown as {
+        isEuler: boolean;
+        __x: number;
+        __y: number;
+        __z: number;
+        __order: Euler['order'];
+        sx: number;
+        sy: number;
+        sz: number;
+        sw: number;
+        q: QuatView;
+    };
+    self.isEuler = true;
+    self.__x = source.x;
+    self.__y = source.y;
+    self.__z = source.z;
+    self.__order = source.order;
+    self.sx = q.t[0];
+    self.sy = q.t[1];
+    self.sz = q.t[2];
+    self.sw = q.t[3];
+    self.q = q;
+}
+LazyEulerCtor.prototype = Object.create(Euler.prototype, {
+    constructor: { value: Euler },
+    _x: eulerComponent('__x'),
+    _y: eulerComponent('__y'),
+    _z: eulerComponent('__z'),
+    // Sync in the old order before reinterpreting the angles in a new order.
+    _order: {
+        get(this: LazyEuler) {
+            return this.__order;
+        },
+        set(this: LazyEuler, v: Euler['order']) {
+            if (eulerStale(this)) deriveEuler(this);
+            this.__order = v;
+        },
+    },
+});
+const LazyEulerClass = LazyEulerCtor as unknown as new (q: QuatView, source: Euler) => LazyEuler;
+
+export function createMirrorGraph(capacity: number) {
+    const positions: Vec3[] = new Array(capacity);
+    const rotations: Quat[] = new Array(capacity);
+    const scales: Vec3[] = new Array(capacity);
+    const locals: Mat4[] = new Array(capacity);
+    const worlds: Mat4[] = new Array(capacity);
+    const parents: Mat4[] = new Array(capacity);
+    return { capacity, count: 0, version: 0, positions, rotations, scales, locals, worlds, parents };
+}
+export type MirrorGraph = ReturnType<typeof createMirrorGraph>;
+
+/**
+ * Seeds tuples from the current transform and installs views. Extend parents before their
+ * children and pass the parent's `matrixWorld.elements` as `parentWorld`.
+ */
+export function extendTransform(g: MirrorGraph, object: Object3D, parentWorld: Mat4): number {
+    if (g.count >= g.capacity) throw new Error('mirror graph is full');
+    const i = g.count++;
+
+    const p: Vec3 = [object.position.x, object.position.y, object.position.z];
+    const q: Quat = [object.quaternion.x, object.quaternion.y, object.quaternion.z, object.quaternion.w];
+    const s: Vec3 = [object.scale.x, object.scale.y, object.scale.z];
+    g.positions[i] = p;
+    g.rotations[i] = q;
+    g.scales[i] = s;
+    g.locals[i] = object.matrix.elements;
+    g.worlds[i] = object.matrixWorld.elements;
+    g.parents[i] = parentWorld;
+
+    installViews(object, p, q, s);
+    return i;
+}
+
+/** Swaps an object's transform properties for views over the given tuples. */
+export function installViews(object: Object3D, p: Vec3, q: Quat, s: Vec3): void {
+    const position = new Vec3ViewClass(p);
+    const quaternion = new QuatViewClass(q);
+    const scale = new Vec3ViewClass(s);
+    const rotation = new LazyEulerClass(quaternion, object.rotation);
+
+    // Keep explicitly written angles synchronized with their quaternion.
+    rotation._onChange(() => {
+        quaternion.setFromEuler(rotation, false);
+        snapshotEuler(rotation);
+    });
+    // Keep accessors on the views so Object3D retains ordinary data properties.
+    Object.defineProperties(object, {
+        position: { configurable: true, enumerable: true, value: position },
+        rotation: { configurable: true, enumerable: true, value: rotation },
+        quaternion: { configurable: true, enumerable: true, value: quaternion },
+        scale: { configurable: true, enumerable: true, value: scale },
+    });
+}
+
+/** Restores stock transform objects and their Euler and quaternion change callbacks. */
+export function releaseViews(object: Object3D): void {
+    const position = new Vector3().copy(object.position);
+    const quaternion = new Quaternion().copy(object.quaternion);
+    const scale = new Vector3().copy(object.scale);
+    const rotation = new Euler().copy(object.rotation);
+    rotation._onChange(() => {
+        quaternion.setFromEuler(rotation, false);
+    });
+    quaternion._onChange(() => {
+        rotation.setFromQuaternion(quaternion, undefined, false);
+    });
+    Object.defineProperties(object, {
+        position: { configurable: true, enumerable: true, value: position },
+        rotation: { configurable: true, enumerable: true, value: rotation },
+        quaternion: { configurable: true, enumerable: true, value: quaternion },
+        scale: { configurable: true, enumerable: true, value: scale },
+    });
+}
+
+/** Composes every extended node from its tuples and propagates world matrices, parents first. */
+export function propagate(g: MirrorGraph): MirrorGraph {
+    g.version++;
+    const { count, positions, rotations, scales, locals, worlds, parents } = g;
+    for (let i = 0; i < count; i++) {
+        mat4.fromRotationTranslationScale(locals[i], rotations[i], positions[i], scales[i]);
+        mat4.multiply(worlds[i], parents[i], locals[i]);
+    }
+    return g;
+}
+
+/**
+ * Routes subtree updates and ancestor updates from world queries through the flat pass.
+ */
+export function claimSubtree(g: MirrorGraph, root: Object3D): void {
+    root.updateMatrixWorld = () => {
+        propagate(g);
+    };
+    root.updateWorldMatrix = (updateParents?: boolean) => {
+        if (updateParents === true && root.parent !== null) root.parent.updateWorldMatrix(true, false);
+        propagate(g);
+    };
+}

--- a/tst/unit/three/bridge.test.ts
+++ b/tst/unit/three/bridge.test.ts
@@ -1,0 +1,110 @@
+import {
+    BoxGeometry,
+    BufferAttribute,
+    Frustum,
+    InstancedMesh,
+    Matrix4,
+    Mesh,
+    MeshBasicMaterial,
+    Object3D,
+    PerspectiveCamera,
+    Scene,
+    SphereGeometry,
+    Vector3,
+} from 'three';
+import { describe, expect, it } from 'vitest';
+import { mat4, quat, vec3 } from '../../../src';
+import { frustum, sphere } from '../../../src/shapes';
+import {
+    claimTransform,
+    frustumFromCamera,
+    instanceMat4Views,
+    mat4Of,
+    sphereToWorld,
+    vec3FromAttribute,
+    vec3ToAttribute,
+} from '../../../src/three';
+
+describe('three bridge', () => {
+    it('writes instance transforms into the buffer used by three', () => {
+        const a = new InstancedMesh(new BoxGeometry(), new MeshBasicMaterial(), 8);
+        const b = new InstancedMesh(new BoxGeometry(), new MeshBasicMaterial(), 8);
+        const views = instanceMat4Views(a);
+        const dummy = new Object3D();
+        for (let i = 0; i < 8; i++) {
+            const q = quat.setAxisAngle(quat.create(), [0, 1, 0], i * 0.3);
+            mat4.fromRotationTranslationScale(views[i], q, [i, 0, 0], [1, 2, 1]);
+            dummy.position.set(i, 0, 0);
+            dummy.quaternion.setFromAxisAngle(new Vector3(0, 1, 0), i * 0.3);
+            dummy.scale.set(1, 2, 1);
+            dummy.updateMatrix();
+            b.setMatrixAt(i, dummy.matrix);
+        }
+        expect(a.instanceMatrix.array).toEqual(b.instanceMatrix.array);
+    });
+
+    it('culls visible, offscreen and behind-camera meshes like three', () => {
+        const scene = new Scene();
+        const geometry = new SphereGeometry(1, 4, 3);
+        geometry.computeBoundingSphere();
+        for (const position of [new Vector3(0, 0, -5), new Vector3(20, 0, -5), new Vector3(0, 0, 5)]) {
+            const mesh = new Mesh(geometry, new MeshBasicMaterial());
+            mesh.position.copy(position);
+            mesh.scale.set(1, 2, 0.5);
+            scene.add(mesh);
+        }
+        const camera = new PerspectiveCamera(60, 16 / 9, 0.1, 100);
+        camera.updateMatrixWorld();
+        scene.updateMatrixWorld();
+
+        const threeFrustum = new Frustum().setFromProjectionMatrix(
+            new Matrix4().multiplyMatrices(camera.projectionMatrix, camera.matrixWorldInverse),
+        );
+        const f = frustumFromCamera(frustum.create(), camera);
+        const s = sphere.create();
+        const visible: boolean[] = [];
+        for (const mesh of scene.children as Mesh[]) {
+            sphereToWorld(s, geometry.boundingSphere!, mesh.matrixWorld.elements);
+            const result = frustum.intersectsSphere(f, s);
+            expect(result).toBe(threeFrustum.intersectsObject(mesh));
+            visible.push(result);
+        }
+        expect(visible).toEqual([true, false, false]);
+    });
+
+    it('transforms vertex attributes like three', () => {
+        const source = new BoxGeometry().getAttribute('position') as BufferAttribute;
+        const a = new BufferAttribute(new Float32Array(source.count * 3), 3);
+        const b = new BufferAttribute(new Float32Array(source.count * 3), 3);
+        const matrix = new Matrix4().makeRotationY(0.4).setPosition(1, 2, 3);
+        const v = vec3.create();
+        const w = new Vector3();
+        for (let i = 0; i < source.count; i++) {
+            vec3.transformMat4(v, vec3FromAttribute(v, source, i), mat4Of(matrix));
+            vec3ToAttribute(a, v, i);
+            w.fromBufferAttribute(source, i).applyMatrix4(matrix);
+            b.setXYZ(i, w.x, w.y, w.z);
+        }
+        expect(a.array).toEqual(b.array);
+    });
+
+    it('preserves caller-owned matrices during three updates', () => {
+        const mesh = new Mesh(new BoxGeometry(), new MeshBasicMaterial());
+        const { world } = claimTransform(mesh);
+        mat4.fromRotationTranslationScale(world, quat.create(), [4, 5, 6], [1, 1, 1]);
+        mesh.position.set(9, 9, 9);
+        mesh.updateMatrixWorld(true);
+        expect(mesh.matrixWorld.elements.slice(12, 15)).toEqual([4, 5, 6]);
+    });
+
+    it('honors normalized attributes like getX and setXYZ', () => {
+        const a = new BufferAttribute(new Uint8Array([255, 128, 0]), 3, true);
+        const v = vec3FromAttribute(vec3.create(), a, 0);
+        expect(v).toEqual([a.getX(0), a.getY(0), a.getZ(0)]);
+        const b = new BufferAttribute(new Uint8Array(3), 3, true);
+        const c = new BufferAttribute(new Uint8Array(3), 3, true);
+        vec3ToAttribute(b, [1, 0.5, 0], 0);
+        c.setXYZ(0, 1, 0.5, 0);
+        expect(b.array).toEqual(c.array);
+    });
+});

--- a/tst/unit/three/extend.test.ts
+++ b/tst/unit/three/extend.test.ts
@@ -1,0 +1,203 @@
+import {
+    AnimationClip,
+    AnimationMixer,
+    Bone,
+    BoxGeometry,
+    MeshBasicMaterial,
+    Object3D,
+    PerspectiveCamera,
+    Scene,
+    Skeleton,
+    SkinnedMesh,
+    Vector3,
+    VectorKeyframeTrack,
+} from 'three';
+import { describe, expect, it } from 'vitest';
+import { quat, vec3 } from '../../../src';
+import { extend, extendObject, release, transformOf, unextend } from '../../../src/three';
+
+// A plain scene and an extended scene are put through the same operations. Three's own
+// updateMatrixWorld on the plain scene is the reference, and world matrices must match exactly.
+
+function makeScene(count: number) {
+    const scene = new Scene();
+    const objects: Object3D[] = [];
+    for (let i = 0; i < count; i++) {
+        const object = new Object3D();
+        (i === 0 ? scene : objects[(i - 1) >> 2]).add(object);
+        object.position.set(i * 0.1, 1, -i * 0.05);
+        object.rotation.set(0, i * 0.01, 0.2);
+        objects.push(object);
+    }
+    scene.updateMatrixWorld();
+    return { scene, objects };
+}
+
+function worlds(scene: Scene): number[] {
+    const out: number[] = [];
+    scene.traverse((object) => out.push(...object.matrixWorld.elements));
+    return out;
+}
+
+describe('extend', () => {
+    it('drives three from records: write position and rotation tuples, three renders the result', () => {
+        const plain = makeScene(64);
+        const { scene, objects } = makeScene(64);
+        extend(scene);
+        for (const [i, object] of objects.entries()) {
+            const t = transformOf(object);
+            vec3.set(t.position, i, 2, 3);
+            quat.setAxisAngle(t.rotation, [0, 1, 0], i * 0.1);
+            plain.objects[i].position.set(i, 2, 3);
+            plain.objects[i].quaternion.setFromAxisAngle(new Vector3(0, 1, 0), i * 0.1);
+        }
+        scene.updateMatrixWorld();
+        plain.scene.updateMatrixWorld();
+        expect(worlds(scene)).toEqual(worlds(plain.scene));
+        // the Object3D interface reads what the records hold
+        expect(objects[5].position.x).toBe(5);
+        expect(objects[5].rotation.y).toBe(plain.objects[5].rotation.y);
+        // the record aliases the matrices three renders from
+        expect(transformOf(objects[5]).world).toBe(objects[5].matrixWorld.elements);
+    });
+
+    it("keeps three's API working: position, rotation, quaternion and scale writes land in the records", () => {
+        const plain = makeScene(16);
+        const { scene, objects } = makeScene(16);
+        extend(scene);
+        for (const [i, object] of objects.entries()) {
+            object.position.x += 1;
+            object.rotation.y = 2;
+            object.scale.set(2, 1, 0.5);
+            plain.objects[i].position.x += 1;
+            plain.objects[i].rotation.y = 2;
+            plain.objects[i].scale.set(2, 1, 0.5);
+        }
+        scene.updateMatrixWorld();
+        plain.scene.updateMatrixWorld();
+        expect(worlds(scene)).toEqual(worlds(plain.scene));
+        expect(transformOf(objects[3]).scale).toEqual([2, 1, 0.5]);
+        // explicit Euler angles survive a pass until the quaternion changes, as in three
+        objects[3].rotation.y += 0.1;
+        plain.objects[3].rotation.y += 0.1;
+        expect(objects[3].rotation.y).toBe(2.1);
+        scene.updateMatrixWorld();
+        plain.scene.updateMatrixWorld();
+        expect(worlds(scene)).toEqual(worlds(plain.scene));
+    });
+
+    it('follows structural changes: objects added later are extended, removed ones released, attach keeps world transforms', () => {
+        const plain = makeScene(32);
+        const { scene, objects } = makeScene(32);
+        extend(scene);
+        for (const s of [plain, { scene, objects }]) {
+            const added = new Object3D();
+            added.position.set(1, 2, 3);
+            s.objects[5].add(added);
+            s.objects[2].attach(s.objects[30]);
+            s.objects[3].removeFromParent();
+            s.scene.updateMatrixWorld();
+        }
+        expect(worlds(scene)).toEqual(worlds(plain.scene));
+        expect(transformOf(objects[5].children[objects[5].children.length - 1]).position).toEqual([1, 2, 3]);
+        expect(() => transformOf(objects[3])).toThrow();
+    });
+
+    it('keeps an object working when it moves from one extended scene to another', () => {
+        const a = extend(makeScene(8).scene);
+        const b = extend(makeScene(8).scene);
+        const object = a.children[0].children[0];
+        const record = transformOf(object);
+        b.add(object);
+        a.updateMatrixWorld();
+        b.updateMatrixWorld();
+        object.position.x = 7;
+        b.updateMatrixWorld();
+        expect(transformOf(object)).toBe(record);
+        expect(object.matrixWorld.elements[12]).toBe(7);
+    });
+
+    it('lets cameras and skinned meshes run their own updateMatrixWorld', () => {
+        const plain = makeScene(8);
+        const { scene, objects } = makeScene(8);
+        extend(scene);
+        const make = (parent: Object3D) => {
+            const camera = new PerspectiveCamera();
+            camera.position.set(0, 0, 5);
+            parent.add(camera);
+            const bone = new Bone();
+            const skinned = new SkinnedMesh(new BoxGeometry(), new MeshBasicMaterial());
+            skinned.add(bone);
+            skinned.bind(new Skeleton([bone]));
+            parent.add(skinned);
+            return { camera, skinned };
+        };
+        const a = make(plain.objects[7]);
+        const b = make(objects[7]);
+        plain.scene.updateMatrixWorld();
+        scene.updateMatrixWorld();
+        expect(b.camera.matrixWorldInverse.elements).toEqual(a.camera.matrixWorldInverse.elements);
+        expect(b.skinned.bindMatrixInverse.elements).toEqual(a.skinned.bindMatrixInverse.elements);
+    });
+
+    it('works with an AnimationMixer created after extend', () => {
+        const plain = makeScene(4);
+        const { scene, objects } = makeScene(4);
+        extend(scene);
+        const clip = new AnimationClip('move', 1, [new VectorKeyframeTrack('.position', [0, 1], [0, 0, 0, 1, 2, 3])]);
+        const mixers = [plain.objects[2], objects[2]].map((target) => {
+            const mixer = new AnimationMixer(target);
+            mixer.clipAction(clip).play();
+            return mixer;
+        });
+        for (const mixer of mixers) mixer.update(0.5);
+        plain.scene.updateMatrixWorld();
+        scene.updateMatrixWorld();
+        expect(worlds(scene)).toEqual(worlds(plain.scene));
+        expect(transformOf(objects[2]).position[1]).toBe(1);
+    });
+
+    it('extendObject covers objects outside the scene, such as a camera, across scene updates', () => {
+        const { scene } = makeScene(4);
+        extend(scene);
+        const camera = new PerspectiveCamera();
+        const t = extendObject(camera);
+        vec3.set(t.position, 1, 2, 3);
+        camera.updateMatrixWorld();
+        expect(camera.position.toArray()).toEqual([1, 2, 3]);
+        expect(camera.matrixWorld.elements.slice(12, 15)).toEqual([1, 2, 3]);
+        // the scene updating, including a rebuild after a structural change, leaves the camera alone
+        scene.add(new Object3D());
+        scene.updateMatrixWorld();
+        vec3.set(t.position, 4, 5, 6);
+        camera.updateMatrixWorld();
+        expect(transformOf(camera)).toBe(t);
+        expect(camera.matrixWorld.elements.slice(12, 15)).toEqual([4, 5, 6]);
+        release(camera);
+        expect(() => transformOf(camera)).toThrow();
+    });
+
+    it('release and unextend put plain three back and the scene keeps updating', () => {
+        const plain = makeScene(16);
+        const { scene, objects } = makeScene(16);
+        extend(scene);
+        release(objects[4]);
+        expect(() => transformOf(objects[4])).toThrow();
+        // a released object still reports hierarchy changes while it stays in the scene
+        const child = new Object3D();
+        objects[4].add(child);
+        plain.objects[4].add(new Object3D());
+        scene.updateMatrixWorld();
+        expect(transformOf(child)).toBeDefined();
+
+        unextend(scene);
+        expect(() => transformOf(objects[1])).toThrow();
+        expect(Object.keys(objects[1].position)).toEqual(['x', 'y', 'z']);
+        for (const s of [plain, { scene, objects }]) {
+            s.objects[1].position.x = 9;
+            s.objects[4].add(new Object3D());
+            s.scene.updateMatrixWorld();
+        }
+        expect(worlds(scene)).toEqual(worlds(plain.scene));
+    });
+});


### PR DESCRIPTION
Adds a zero-copy bridge for Three while keeping the usual Object3D math interfaces like position, scale, rotation and quaternion synced. No patching, all userland code.

Basically, we take advantage of the fact that the Three Matrix4 are already array backed and directly copied for GPU buffers. We take this over and then replace the Object3D math objects with our own that access the Math tuples via getters and setters. This makes using Math path very fast with a small hit to perf (the cost of accessors) on the Object3D path. In hot paths we get a 1.4-2.7x speedup.

| Workload | Vanilla three | math/three | Speedup |
| --- | ---: | ---: | ---: |
| Instanced transforms, 10 000 instances | 728 µs | 318 µs | 2.3× |
| Scene graph, 4 096 nodes (`extend`) | 777 µs | 331 µs | 2.3× |
| Scene graph, 4 096 nodes (per-object mirror) | 777 µs | 284 µs | 2.7× |
| Frustum culling, 4 096 meshes | 293 µs | 152 µs | 1.9× |
| Vertex transform, 8 481 vertices | 127 µs | 59 µs | 2.2× |
| Scene graph step + read every position/rotation | 820 µs | 606 µs | 1.4× |

The API uses a handle to get the Math tuples associated with the Object3D.

```js
extend(scene);      // returns the scene math-backed
const t = transformOf(mesh);  // { position, rotation, scale, local, world }
vec3.set(t.position, x, y, z);      // the fast path
```



